### PR TITLE
read `PARTYKIT_API_BASE` from `process.env`, with a production default

### DIFF
--- a/.changeset/fresh-guests-press.md
+++ b/.changeset/fresh-guests-press.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+read `PARTYKIT_API_BASE` from `process.env`, with a production default

--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -25,7 +25,7 @@
     "ws": "^8.11.0"
   },
   "scripts": {
-    "start": "node -r esbuild-register --watch --watch-path src scripts/build.ts",
-    "build": "node -r esbuild-register scripts/build.ts --minify"
+    "start": "PARTYKIT_API_BASE=http://127.0.0.1:8787 node -r esbuild-register --watch --watch-path src scripts/build.ts",
+    "build": "PARTYKIT_API_BASE=https://api.partykit.dev node -r esbuild-register scripts/build.ts --minify"
   }
 }

--- a/packages/partykit/scripts/build.ts
+++ b/packages/partykit/scripts/build.ts
@@ -18,6 +18,9 @@ esbuild.buildSync({
   external: ["esbuild", "clipboardy", "@edge-runtime/primitives"],
   sourcemap: true,
   minify,
+  define: {
+    PARTYKIT_API_BASE: `"${process.env.PARTYKIT_API_BASE}"`,
+  },
 });
 
 fs.chmodSync("dist/bin.js", 0o755);
@@ -30,6 +33,7 @@ esbuild.buildSync({
   outfile: "dist/client.js",
   sourcemap: true,
   minify,
+
   // platform: "browser", // ?neutral?
 });
 

--- a/packages/partykit/src/fetchResult.ts
+++ b/packages/partykit/src/fetchResult.ts
@@ -1,4 +1,9 @@
-const API_BASE = process.env.API_BASE || "http://127.0.0.1:8787";
+import assert from "assert";
+
+declare const PARTYKIT_API_BASE: string | undefined;
+assert(PARTYKIT_API_BASE, "PARTYKIT_API_BASE is not defined");
+
+const API_BASE = process.env.PARTYKIT_BASE || PARTYKIT_API_BASE;
 
 export async function fetchResult<T>(
   api: string,

--- a/packages/partykit/src/tests/publish.test.ts
+++ b/packages/partykit/src/tests/publish.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { publish } from "../cli";
 import { mockFetchResult, clearMocks } from "./fetchResult-mock";
 
-const fixture = `${__dirname}/fixture.js`;
-
 vi.mock("../fetchResult", async () => {
   const { fetchResult } = await import("./fetchResult-mock");
   return {
     fetchResult,
   };
 });
+
+const fixture = `${__dirname}/fixture.js`;
 
 process.env.GITHUB_LOGIN = "test-user";
 process.env.GITHUB_TOKEN = "test-token";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
     reporters: ["verbose"],
     threads: false,
     testTimeout: 1000,
-    // maxThreads: 1,
-    // ...
+    setupFiles: ["./vitest.setup.js"],
   },
 });

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-undef
+globalThis.PARTYKIT_API_BASE = "fuck.partykit.dev";


### PR DESCRIPTION
This should unblock actually using the cli, bit for my own dev, as well as external usage (once we actually deploy to api.partykit.dev)