### PR TITLE
fix exports/typings

### DIFF
--- a/.changeset/twelve-donuts-deny.md
+++ b/.changeset/twelve-donuts-deny.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+fix exports/typings
+
+This patch fixes how we generate types (by actually doing so), configuring exports in package.json, and making sure it points to the right thing. I had to write a script that moves the generated types to the root for... javascript reasons ™ but at least it works now. good enough.

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -35,7 +35,6 @@ jobs:
         run: node .github/version-script.js
 
       - run: npm run build
-
       - run: npm run check
 
       - run: npm publish --tag beta

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -27,5 +27,4 @@ jobs:
       - run: npm ci
 
       - run: npm run build
-
       - run: npm run check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
       - run: npm ci
 
       - run: npm run build
-
       - run: npm run check
 
       - id: changesets

--- a/examples/basic/src/client.ts
+++ b/examples/basic/src/client.ts
@@ -1,6 +1,7 @@
-import { PartySocket } from "partykit/src/client";
+import { PartySocket } from "partykit/client";
 
 const partySocket = new PartySocket({
+  // host: "testy.threepointone.partykit.dev",
   host: "localhost:1999",
   room: "some-room",
 });

--- a/packages/partykit/.gitignore
+++ b/packages/partykit/.gitignore
@@ -1,0 +1,3 @@
+*.d.ts
+*.d.ts.map
+dts

--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.1",
   "description": "Everything's better with friends",
   "bin": "dist/bin.js",
-  "main": "dist/index.js",
+  "exports": {
+    "./client": "./dist/client.js",
+    "./server": "./dist/server.js"
+  },
   "dependencies": {
     "@edge-runtime/primitives": "^2.0.2",
     "clipboardy": "^3.0.0",
@@ -24,8 +27,14 @@
     "reconnecting-websocket": "^4.4.0",
     "ws": "^8.11.0"
   },
+  "files": [
+    "dist",
+    "*.d.ts",
+    "*.d.ts.map"
+  ],
   "scripts": {
-    "start": "PARTYKIT_API_BASE=http://127.0.0.1:8787 node -r esbuild-register --watch --watch-path src scripts/build.ts",
-    "build": "PARTYKIT_API_BASE=https://api.partykit.dev node -r esbuild-register scripts/build.ts --minify"
+    "clean": "rm -rf dist && rm -rf dts && rm -rf *.d.ts && rm -rf *.d.ts.map && mkdir dts",
+    "start": "npm run clean && concurrently \"PARTYKIT_API_BASE=http://127.0.0.1:8787 node -r esbuild-register --watch --watch-path src scripts/build.ts\" \"tsc -p scripts/tsconfig.extract.json --watch\" \"node -r esbuild-register --watch --watch-path dts scripts/copy-dts.ts\" --kill-others",
+    "build": "npm run clean && PARTYKIT_API_BASE=https://api.partykit.dev node -r esbuild-register scripts/build.ts --minify && tsc -p scripts/tsconfig.extract.json --incremental false && node -r esbuild-register scripts/copy-dts.ts"
   }
 }

--- a/packages/partykit/scripts/build.ts
+++ b/packages/partykit/scripts/build.ts
@@ -3,9 +3,6 @@ import * as fs from "fs";
 
 process.chdir(`${__dirname}/../`);
 
-// clean build folder
-fs.rmSync("dist", { recursive: true, force: true });
-
 const minify = process.argv.includes("--minify");
 
 // generate bin/index.js
@@ -33,7 +30,6 @@ esbuild.buildSync({
   outfile: "dist/client.js",
   sourcemap: true,
   minify,
-
   // platform: "browser", // ?neutral?
 });
 
@@ -47,11 +43,3 @@ esbuild.buildSync({
   minify,
   // platform: "node", // ?neutral?
 });
-
-// generate a barrel file for the dist folder
-// TODO: should probably add a log asking them to import
-// from the individual files instead of the barrel file
-fs.writeFileSync(
-  "dist/index.js",
-  `export * from './client.js'; export * from './server.js';`
-);

--- a/packages/partykit/scripts/copy-dts.ts
+++ b/packages/partykit/scripts/copy-dts.ts
@@ -1,0 +1,16 @@
+// because tsc is expecting the typings to be at the root,
+// we use this script to copy the generated .d.ts files to the root
+// we can't just --outDir in tsconfig.extract.json to be root
+// since that adds tge root to `exclude` 😖
+
+// move all files files from ../dts to ..
+import * as fs from "fs";
+import * as path from "path";
+
+const dtsDir = path.join(__dirname, "../dts");
+const files = fs.readdirSync(dtsDir);
+for (const file of files) {
+  if (file.endsWith(".d.ts") || file.endsWith(".map")) {
+    fs.cpSync(path.join(dtsDir, file), path.join(__dirname, "../", file));
+  }
+}

--- a/packages/partykit/scripts/tsconfig.extract.json
+++ b/packages/partykit/scripts/tsconfig.extract.json
@@ -1,0 +1,13 @@
+// only used during builds to extract .d.ts files
+
+{
+  "extends": "../tsconfig.json",
+  "include": ["../src/client.ts", "../src/server.ts"],
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "../dts" // we can't set this to '../' since that adds it to `exclude`, removing our included files as well 😖
+  }
+}


### PR DESCRIPTION
This patch fixes how we generate types (by actually doing so), configuring exports in package.json, and making sure it points to the right thing. I had to write a script that moves the generated types to the root for... javascript reasons ™ but at least it works now. good enough.