### PR TITLE
add `unstable_onValidate`

### DIFF
--- a/.changeset/two-laws-fry.md
+++ b/.changeset/two-laws-fry.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+add `unstable_onValidate`
+
+This adds `unstable_onValidate` to server's default export, alongside onConnect. Users are expected to implement this and return a boolean, that will reject the connection when false.

--- a/examples/basic/src/server.ts
+++ b/examples/basic/src/server.ts
@@ -1,12 +1,13 @@
 export default {
   onConnect(ws: WebSocket) {
+    // your business logic here
     ws.onmessage = function incoming(evt) {
-      console.log("evt!", evt.data);
-      ws.send("pong");
+      if (evt.data === "ping") {
+        ws.send("pong");
+      }
     };
   },
-  // this doesn't work just yet...
-  // onRequest(_req: Request) {
-  //   return new Response("Yoohoo from the room");
-  // }
+  async unstable_onValidate(_req: Request): Promise<boolean> {
+    return true;
+  },
 };

--- a/packages/partykit/src/cli.ts
+++ b/packages/partykit/src/cli.ts
@@ -153,15 +153,15 @@ export async function dev(
       const roomId = url.pathname.split("/")[2];
       const room = await getRoom(roomId);
 
-      // TODO: implement onRequest
-      // const response = room.runtime.dispatchFetch(request.url, {
-      //   headers: request.rawHeaders.reduce((acc, cur, i) => {
-      //     if (i % 2 === 0) {
-      //       acc[cur] = request.rawHeaders[i + 1];
-      //     }
-      //     return acc;
-      //   }, {}),
-      // });
+      const res = await room.runtime.dispatchFetch(
+        `http://${request.headers.host}${request.url}`,
+        // @ts-expect-error TODO: fix this, set-cookies may be a string[]
+        { headers: request.headers }
+      );
+
+      if (res.status === 401) {
+        socket.destroy();
+      }
 
       room.ws.handleUpgrade(request, socket, head, function done(ws) {
         room.ws.emit("connection", ws, request);

--- a/packages/partykit/src/tests/dev.test.ts
+++ b/packages/partykit/src/tests/dev.test.ts
@@ -29,7 +29,7 @@ describe("dev", () => {
     await runDev(fixture, {});
     const res = await fetch("http://localhost:1999/party/theroom");
     expect(await res.text()).toMatchInlineSnapshot(
-      '"Hello world from the room"'
+      '"Not found"'
     );
   });
 
@@ -37,7 +37,7 @@ describe("dev", () => {
     await runDev(fixture, { port: 9999 });
     const res = await fetch("http://localhost:9999/party/theroom");
     expect(await res.text()).toMatchInlineSnapshot(
-      '"Hello world from the room"'
+      '"Not found"'
     );
   });
 


### PR DESCRIPTION
This adds `unstable_onValidate` to server's default export, alongside onConnect. Users are expected to implement this and return a boolean, that will reject the connection when false.