### PR TITLE
manually publish prereleases

### DIFF
--- a/.github/changeset-version.js
+++ b/.github/changeset-version.js
@@ -5,9 +5,5 @@ const { execSync } = require("node:child_process");
 // So we also run `npm install`, which does this update.
 // This is a workaround until this is handled automatically by `changeset version`.
 // See https://github.com/changesets/changesets/issues/421.
-execSync(
-  `npx changeset version${
-    process.argv.includes("--snapshot") ? ` --snapshot` : ""
-  }`
-);
+execSync("npx changeset version");
 execSync("npm install");

--- a/.github/version-script.js
+++ b/.github/version-script.js
@@ -1,0 +1,22 @@
+const fs = require("fs");
+const { exec } = require("child_process");
+
+try {
+  exec("git rev-parse --short HEAD", (err, stdout) => {
+    if (err) {
+      console.log(err);
+      process.exit(1);
+    }
+    for (const path of [
+      "./packages/partykit/package.json",
+      "./packages/y-partykit/package.json",
+    ]) {
+      const package = JSON.parse(fs.readFileSync(path));
+      package.version = "0.0.0-" + stdout.trim();
+      fs.writeFileSync(path, JSON.stringify(package, null, "\t") + "\n");
+    }
+  });
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -31,15 +31,18 @@ jobs:
 
       - run: npm ci
 
+      - name: Modify package.json version
+        run: node .github/version-script.js
+
       - run: npm run build
       - run: npm run check
 
-      - id: changesets
-        uses: changesets/action@v1
-        with:
-          version: node .github/changeset-version.js --snapshot
-          publish: npx changeset publish --no-git-tag --tag beta
+      - run: npm publish --tag beta
         env:
-          GITHUB_TOKEN: ${{ secrets.PARTYKIT_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        working-directory: packages/partykit
+
+      - run: npm publish --tag beta
+        env:
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        working-directory: packages/y-partykit


### PR DESCRIPTION
This reverts part of commit 1e252b5da31a4e1d0f053ba960085fcd7a303718. Looks like the changesets action doesn't care about snapshot releases. But let's publish beta versions of y-partykit anyway.