### PR TITLE
partysocket: fork `reconnecting-websocket`

### DIFF
--- a/.changeset/rude-games-lay.md
+++ b/.changeset/rude-games-lay.md
@@ -1,0 +1,7 @@
+---
+"partysocket": patch
+---
+
+partysocket
+
+partysocket is a for of reconnecting-websocket (which appears to be abandoned), that adds a few missing features and fixes a few bugs.

--- a/.github/version-script.js
+++ b/.github/version-script.js
@@ -10,6 +10,7 @@ try {
     for (const path of [
       "./packages/partykit/package.json",
       "./packages/y-partykit/package.json",
+      "./packages/partysocket/package.json",
     ]) {
       const package = JSON.parse(fs.readFileSync(path));
       package.version = "0.0.0-" + stdout.trim();

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -46,3 +46,8 @@ jobs:
         env:
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
         working-directory: packages/y-partykit
+
+      - run: npm publish --tag beta
+        env:
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        working-directory: packages/partysocket

--- a/examples/basic/src/client.ts
+++ b/examples/basic/src/client.ts
@@ -1,7 +1,6 @@
-import { PartySocket } from "partykit/client";
+import PartySocket from "partysocket";
 
 const partySocket = new PartySocket({
-  // host: "testy.threepointone.partykit.dev",
   host: "localhost:1999",
   room: "some-room",
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6555,6 +6555,10 @@
       "resolved": "packages/partykit",
       "link": true
     },
+    "node_modules/partysocket": {
+      "resolved": "packages/partysocket",
+      "link": true
+    },
     "node_modules/patch-package": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
@@ -7164,12 +7168,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/reconnecting-websocket": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
-      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng==",
-      "dev": true
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -9009,7 +9007,6 @@
         "find-config": "^1.0.0",
         "http-proxy": "^1.18.1",
         "open": "^8.4.0",
-        "reconnecting-websocket": "^4.4.0",
         "ws": "^8.11.0"
       }
     },
@@ -9051,6 +9048,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/partysocket": {
+      "version": "0.0.1",
+      "license": "ISC"
+    },
     "packages/y-party": {
       "version": "0.0.0",
       "extraneous": true,
@@ -9067,7 +9068,6 @@
         "lib0": "^0.2.58",
         "lodash.debounce": "^4.0.8",
         "y-protocols": "^1.0.5",
-        "y-websocket": "^1.4.5",
         "yjs": "^13.5.44"
       }
     }
@@ -13844,7 +13844,6 @@
         "find-config": "^1.0.0",
         "http-proxy": "^1.18.1",
         "open": "^8.4.0",
-        "reconnecting-websocket": "^4.4.0",
         "ws": "^8.11.0"
       },
       "dependencies": {
@@ -13872,6 +13871,9 @@
           }
         }
       }
+    },
+    "partysocket": {
+      "version": "file:packages/partysocket"
     },
     "patch-package": {
       "version": "6.5.1",
@@ -14305,12 +14307,6 @@
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
-    },
-    "reconnecting-websocket": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
-      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng==",
-      "dev": true
     },
     "redent": {
       "version": "3.0.0",
@@ -15539,7 +15535,6 @@
         "lib0": "^0.2.58",
         "lodash.debounce": "^4.0.8",
         "y-protocols": "^1.0.5",
-        "y-websocket": "^1.4.5",
         "yjs": "^13.5.44"
       }
     },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "start": "npm start -w partykit",
-    "build": "npm run build -w partykit -w y-partykit",
+    "build": "npm run build -w partykit -w y-partykit -w partysocket",
     "check": "npm run lint && npm run repocheck && npm run typecheck && npx vitest --watch=false",
     "lint": "npx eslint \"**/*.[tj]s?(x)\" --max-warnings=0 --cache",
     "test": "vitest",

--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -4,8 +4,8 @@
   "description": "Everything's better with friends",
   "bin": "dist/bin.js",
   "exports": {
-    "./client": "./dist/client.js",
-    "./server": "./dist/server.js"
+    "./server": "./dist/server.js",
+    "./src/cli": "./src/cli.ts"
   },
   "dependencies": {
     "@edge-runtime/primitives": "^2.0.2",
@@ -27,7 +27,6 @@
     "find-config": "^1.0.0",
     "http-proxy": "^1.18.1",
     "open": "^8.4.0",
-    "reconnecting-websocket": "^4.4.0",
     "ws": "^8.11.0"
   },
   "files": [

--- a/packages/partykit/scripts/build.ts
+++ b/packages/partykit/scripts/build.ts
@@ -33,17 +33,6 @@ esbuild.buildSync({
 
 fs.chmodSync("dist/bin.js", 0o755);
 
-// generate dist/client.js
-esbuild.buildSync({
-  entryPoints: ["src/client.ts"],
-  bundle: true,
-  format: "esm",
-  outfile: "dist/client.js",
-  sourcemap: true,
-  minify,
-  // platform: "browser", // ?neutral?
-});
-
 // generate dist/server.js
 esbuild.buildSync({
   entryPoints: ["src/server.ts"],

--- a/packages/partykit/scripts/tsconfig.extract.json
+++ b/packages/partykit/scripts/tsconfig.extract.json
@@ -2,7 +2,7 @@
 
 {
   "extends": "../tsconfig.json",
-  "include": ["../src/client.ts", "../src/server.ts"],
+  "include": ["../src/server.ts"],
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,

--- a/packages/partysocket/README.md
+++ b/packages/partysocket/README.md
@@ -1,0 +1,213 @@
+- https://github.com/pladaria/reconnecting-websocket/pull/166 Fix: handle error if getNextUrl throws (TODO: add test for this one )
+- https://github.com/pladaria/reconnecting-websocket/pull/132 feat: make protocols updatable
+- https://github.com/pladaria/reconnecting-websocket/pull/141 [Fix] Socket doesn't connect again after closing while connecting
+
+(TODO: more)
+
+- https://github.com/pladaria/reconnecting-websocket/pull/163 Support for Dynamic Protocols
+- https://github.com/pladaria/reconnecting-websocket/pull/47 reconnecting and reconnectscheduled custom events
+
+# Reconnecting WebSocket
+
+[![Build Status](https://travis-ci.org/pladaria/reconnecting-websocket.svg?branch=master&v=1)](https://travis-ci.org/pladaria/reconnecting-websocket)
+[![Coverage Status](https://coveralls.io/repos/github/pladaria/reconnecting-websocket/badge.svg?branch=master&v=3)](https://coveralls.io/github/pladaria/reconnecting-websocket?branch=master)
+
+WebSocket that will automatically reconnect if the connection is closed.
+
+## Features
+
+- WebSocket API compatible (same interface, Level0 and Level2 event model)
+- Fully configurable
+- Multi-platform (Web, ServiceWorkers, Node.js, React Native)
+- Dependency free (does not depend on Window, DOM or any EventEmitter library)
+- Handle connection timeouts
+- Allows changing server URL between reconnections
+- Buffering. Will send accumulated messages on open
+- Multiple builds available (see dist folder)
+- Debug mode
+
+## Install
+
+```bash
+npm install --save reconnecting-websocket
+```
+
+## Usage
+
+### Compatible with WebSocket Browser API
+
+So this documentation should be valid:
+[MDN WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket).
+
+Ping me if you find any problems. Or, even better, write a test for your case and make a pull
+request :)
+
+### Simple usage
+
+```javascript
+import ReconnectingWebSocket from "reconnecting-websocket";
+
+const rws = new ReconnectingWebSocket("ws://my.site.com");
+
+rws.addEventListener("open", () => {
+  rws.send("hello!");
+});
+```
+
+### Update URL
+
+The `url` parameter will be resolved before connecting, possible types:
+
+- `string`
+- `() => string`
+- `() => Promise<string>`
+
+```javascript
+import ReconnectingWebSocket from "reconnecting-websocket";
+
+const urls = ["ws://my.site.com", "ws://your.site.com", "ws://their.site.com"];
+let urlIndex = 0;
+
+// round robin url provider
+const urlProvider = () => urls[urlIndex++ % urls.length];
+
+const rws = new ReconnectingWebSocket(urlProvider);
+```
+
+```javascript
+import ReconnectingWebSocket from "reconnecting-websocket";
+
+// async url provider
+const urlProvider = async () => {
+  const token = await getSessionToken();
+  return `wss://my.site.com/${token}`;
+};
+
+const rws = new ReconnectingWebSocket(urlProvider);
+```
+
+### Update Protocols
+
+The `protocols` parameter will be resolved before connecting, possible types:
+
+- `null`
+- `string`
+- `string[]`
+- `() => string | string[] | null`
+- `() => Promise<string | string[] | null>`
+
+```javascript
+import ReconnectingWebSocket from 'reconnecting-websocket`;
+const rws = new ReconnectingWebSocket('ws://your.site.com', 'your protocol');
+```
+
+```javascript
+import ReconnectingWebSocket from 'reconnecting-websocket`;
+
+const protocols = ['p1', 'p2', ['p3.1', 'p3.2']];
+let protocolsIndex = 0;
+
+// round robin protocols provider
+const protocolsProvider = () => protocols[protocolsIndex++ % protocols.length];
+
+const rws = new ReconnectingWebSocket('ws://your.site.com', protocolsProvider);
+```
+
+### Options
+
+#### Sample with custom options
+
+```javascript
+import ReconnectingWebSocket from "reconnecting-websocket";
+import WS from "ws";
+
+const options = {
+  WebSocket: WS, // custom WebSocket constructor
+  connectionTimeout: 1000,
+  maxRetries: 10,
+};
+const rws = new ReconnectingWebSocket("ws://my.site.com", [], options);
+```
+
+#### Available options
+
+```typescript
+type Options = {
+  WebSocket?: any; // WebSocket constructor, if none provided, defaults to global WebSocket
+  maxReconnectionDelay?: number; // max delay in ms between reconnections
+  minReconnectionDelay?: number; // min delay in ms between reconnections
+  reconnectionDelayGrowFactor?: number; // how fast the reconnection delay grows
+  minUptime?: number; // min time in ms to consider connection as stable
+  connectionTimeout?: number; // retry connect if not connected after this time, in ms
+  maxRetries?: number; // maximum number of retries
+  maxEnqueuedMessages?: number; // maximum number of messages to buffer until reconnection
+  startClosed?: boolean; // start websocket in CLOSED state, call `.reconnect()` to connect
+  debug?: boolean; // enables debug output
+};
+```
+
+#### Default values
+
+```javascript
+WebSocket: undefined,
+maxReconnectionDelay: 10000,
+minReconnectionDelay: 1000 + Math.random() * 4000,
+reconnectionDelayGrowFactor: 1.3,
+minUptime: 5000,
+connectionTimeout: 4000,
+maxRetries: Infinity,
+maxEnqueuedMessages: Infinity,
+startClosed: false,
+debug: false,
+```
+
+## API
+
+### Methods
+
+```typescript
+constructor(url: UrlProvider, protocols?: ProtocolsProvider, options?: Options)
+
+close(code?: number, reason?: string)
+reconnect(code?: number, reason?: string)
+
+send(data: string | ArrayBuffer | Blob | ArrayBufferView)
+
+addEventListener(type: 'open' | 'close' | 'message' | 'error', listener: EventListener)
+removeEventListener(type:  'open' | 'close' | 'message' | 'error', listener: EventListener)
+```
+
+### Attributes
+
+[More info](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
+
+```typescript
+binaryType: string;
+bufferedAmount: number;
+extensions: string;
+onclose: EventListener;
+onerror: EventListener;
+onmessage: EventListener;
+onopen: EventListener;
+protocol: string;
+readyState: number;
+url: string;
+retryCount: number;
+```
+
+### Constants
+
+```text
+CONNECTING 0 The connection is not yet open.
+OPEN       1 The connection is open and ready to communicate.
+CLOSING    2 The connection is in the process of closing.
+CLOSED     3 The connection is closed or couldn't be opened.
+```
+
+## Contributing
+
+[Read here](./CONTRIBUTING.md)
+
+## License
+
+MIT

--- a/packages/partysocket/package.json
+++ b/packages/partysocket/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "partysocket",
+  "version": "0.0.1",
+  "private": true,
+  "description": "party hotline",
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "npx esbuild src/index.ts --bundle --format=esm --outfile=dist/index.js && tsc --project tsconfig.extract.json"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/partysocket/src/events.ts
+++ b/packages/partysocket/src/events.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export class Event {
+  public target: any;
+  public type: string;
+  constructor(type: string, target: any) {
+    this.target = target;
+    this.type = type;
+  }
+}
+
+export class ErrorEvent extends Event {
+  public message: string;
+  public error: Error;
+  constructor(error: Error, target: any) {
+    super("error", target);
+    this.message = error.message;
+    this.error = error;
+  }
+}
+
+export class CloseEvent extends Event {
+  public code: number;
+  public reason: string;
+  public wasClean = true;
+  constructor(code = 1000, reason = "", target: any) {
+    super("close", target);
+    this.code = code;
+    this.reason = reason;
+  }
+}
+export interface WebSocketEventMap {
+  close: CloseEvent;
+  error: ErrorEvent;
+  message: MessageEvent;
+  open: Event;
+}
+
+export interface WebSocketEventListenerMap {
+  close: (
+    event: CloseEvent
+  ) => void | { handleEvent: (event: CloseEvent) => void };
+  error: (
+    event: ErrorEvent
+  ) => void | { handleEvent: (event: ErrorEvent) => void };
+  message: (
+    event: MessageEvent
+  ) => void | { handleEvent: (event: MessageEvent) => void };
+  open: (event: Event) => void | { handleEvent: (event: Event) => void };
+}

--- a/packages/partysocket/src/index.ts
+++ b/packages/partysocket/src/index.ts
@@ -1,7 +1,10 @@
-import type * as RWS from "reconnecting-websocket";
-import ReconnectingWebSocket from "reconnecting-websocket";
+import type * as RWS from "./reconnecting-websocket";
+import ReconnectingWebSocket from "./reconnecting-websocket";
 
-type PartySocketOptions = Omit<RWS.Options, "WebSocket" | "constructor"> & {
+export type PartySocketOptions = Omit<
+  RWS.Options,
+  "WebSocket" | "constructor"
+> & {
   host: string; // base url for the party
   room: string; // the room to connect to
   protocol?: string;
@@ -17,7 +20,7 @@ type PartySocketOptions = Omit<RWS.Options, "WebSocket" | "constructor"> & {
 
 // extremely basic for now but we'll add more options later
 // TODO: incorporate the above notes
-export class PartySocket extends ReconnectingWebSocket {
+export default class PartySocket extends ReconnectingWebSocket {
   _pk: string;
   constructor(readonly partySocketOptions: PartySocketOptions) {
     const { host, room, protocol, query, protocols, ...socketOptions } =

--- a/packages/partysocket/src/reconnecting-websocket.ts
+++ b/packages/partysocket/src/reconnecting-websocket.ts
@@ -1,0 +1,604 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/*!
+ * Reconnecting WebSocket
+ * by Pedro Ladaria <pedro.ladaria@gmail.com>
+ * https://github.com/pladaria/reconnecting-websocket
+ * License MIT
+ */
+
+import * as Events from "./events";
+
+function assert(condition: unknown, msg?: string): asserts condition {
+  if (!condition) {
+    throw new Error(msg);
+  }
+}
+
+/**
+ * Returns true if given argument looks like a WebSocket class
+ */
+function isWebSocket(w: unknown): w is WebSocket {
+  return (
+    typeof w !== "undefined" &&
+    !!w &&
+    typeof w === "function" &&
+    "CLOSING" in w &&
+    w.CLOSING === 2
+  );
+}
+
+export type Event = Events.Event;
+export type ErrorEvent = Events.ErrorEvent;
+export type CloseEvent = Events.CloseEvent;
+
+export type Options = {
+  // WebSocket?: any;
+  maxReconnectionDelay?: number;
+  minReconnectionDelay?: number;
+  reconnectionDelayGrowFactor?: number;
+  minUptime?: number;
+  connectionTimeout?: number;
+  maxRetries?: number;
+  maxEnqueuedMessages?: number;
+  startClosed?: boolean;
+  debug?: boolean;
+};
+
+const DEFAULT = {
+  maxReconnectionDelay: 10000,
+  minReconnectionDelay: 1000 + Math.random() * 4000,
+  minUptime: 5000,
+  reconnectionDelayGrowFactor: 1.3,
+  connectionTimeout: 4000,
+  maxRetries: Infinity,
+  maxEnqueuedMessages: Infinity,
+  startClosed: false,
+  debug: false,
+};
+
+export type UrlProvider = string | (() => string) | (() => Promise<string>);
+export type ProtocolsProvider =
+  | null
+  | string
+  | string[]
+  | (() => string | string[] | null)
+  | (() => Promise<string | string[] | null>);
+
+export type Message = string | ArrayBuffer | Blob | ArrayBufferView;
+
+export type ListenersMap = {
+  error: Events.WebSocketEventListenerMap["error"][];
+  message: Events.WebSocketEventListenerMap["message"][];
+  open: Events.WebSocketEventListenerMap["open"][];
+  close: Events.WebSocketEventListenerMap["close"][];
+};
+
+export default class ReconnectingWebSocket {
+  private _ws: WebSocket | undefined;
+  private _listeners: ListenersMap = {
+    error: [],
+    message: [],
+    open: [],
+    close: [],
+  };
+  private _retryCount = -1;
+  private _uptimeTimeout: ReturnType<typeof setTimeout> | undefined;
+  private _connectTimeout: ReturnType<typeof setTimeout> | undefined;
+  private _shouldReconnect = true;
+  private _connectLock = false;
+  private _binaryType: BinaryType = "blob";
+  private _closeCalled = false;
+  private _messageQueue: Message[] = [];
+
+  private readonly _url: UrlProvider;
+  private readonly _protocols?: ProtocolsProvider;
+  private readonly _options: Options;
+
+  constructor(
+    url: UrlProvider,
+    protocols?: ProtocolsProvider,
+    options: Options = {}
+  ) {
+    this._url = url;
+    this._protocols = protocols;
+    this._options = options;
+    if (this._options.startClosed) {
+      this._shouldReconnect = false;
+    }
+    this._connect();
+  }
+
+  static get CONNECTING() {
+    return 0;
+  }
+  static get OPEN() {
+    return 1;
+  }
+  static get CLOSING() {
+    return 2;
+  }
+  static get CLOSED() {
+    return 3;
+  }
+
+  get CONNECTING() {
+    return ReconnectingWebSocket.CONNECTING;
+  }
+  get OPEN() {
+    return ReconnectingWebSocket.OPEN;
+  }
+  get CLOSING() {
+    return ReconnectingWebSocket.CLOSING;
+  }
+  get CLOSED() {
+    return ReconnectingWebSocket.CLOSED;
+  }
+
+  get binaryType() {
+    return this._ws ? this._ws.binaryType : this._binaryType;
+  }
+
+  set binaryType(value: BinaryType) {
+    this._binaryType = value;
+    if (this._ws) {
+      this._ws.binaryType = value;
+    }
+  }
+
+  /**
+   * Returns the number or connection retries
+   */
+  get retryCount(): number {
+    return Math.max(this._retryCount, 0);
+  }
+
+  /**
+   * The number of bytes of data that have been queued using calls to send() but not yet
+   * transmitted to the network. This value resets to zero once all queued data has been sent.
+   * This value does not reset to zero when the connection is closed; if you keep calling send(),
+   * this will continue to climb. Read only
+   */
+  get bufferedAmount(): number {
+    const bytes = this._messageQueue.reduce((acc, message) => {
+      if (typeof message === "string") {
+        acc += message.length; // not byte size
+      } else if (message instanceof Blob) {
+        acc += message.size;
+      } else {
+        acc += message.byteLength;
+      }
+      return acc;
+    }, 0);
+    return bytes + (this._ws ? this._ws.bufferedAmount : 0);
+  }
+
+  /**
+   * The extensions selected by the server. This is currently only the empty string or a list of
+   * extensions as negotiated by the connection
+   */
+  get extensions(): string {
+    return this._ws ? this._ws.extensions : "";
+  }
+
+  /**
+   * A string indicating the name of the sub-protocol the server selected;
+   * this will be one of the strings specified in the protocols parameter when creating the
+   * WebSocket object
+   */
+  get protocol(): string {
+    return this._ws ? this._ws.protocol : "";
+  }
+
+  /**
+   * The current state of the connection; this is one of the Ready state constants
+   */
+  get readyState(): number {
+    if (this._ws) {
+      return this._ws.readyState;
+    }
+    return this._options.startClosed
+      ? ReconnectingWebSocket.CLOSED
+      : ReconnectingWebSocket.CONNECTING;
+  }
+
+  /**
+   * The URL as resolved by the constructor
+   */
+  get url(): string {
+    return this._ws ? this._ws.url : "";
+  }
+
+  /**
+   * Whether the websocket object is now in reconnectable state
+   */
+  get shouldReconnect(): boolean {
+    return this._shouldReconnect;
+  }
+
+  /**
+   * An event listener to be called when the WebSocket connection's readyState changes to CLOSED
+   */
+  public onclose: ((event: Events.CloseEvent) => void) | null = null;
+
+  /**
+   * An event listener to be called when an error occurs
+   */
+  public onerror: ((event: Events.ErrorEvent) => void) | null = null;
+
+  /**
+   * An event listener to be called when a message is received from the server
+   */
+  public onmessage: ((event: MessageEvent) => void) | null = null;
+
+  /**
+   * An event listener to be called when the WebSocket connection's readyState changes to OPEN;
+   * this indicates that the connection is ready to send and receive data
+   */
+  public onopen: ((event: Event) => void) | null = null;
+
+  /**
+   * Closes the WebSocket connection or connection attempt, if any. If the connection is already
+   * CLOSED, this method does nothing
+   */
+  public close(code = 1000, reason?: string) {
+    this._closeCalled = true;
+    this._shouldReconnect = false;
+    this._clearTimeouts();
+    if (!this._ws) {
+      this._debug("close enqueued: no ws instance");
+      return;
+    }
+    if (this._ws.readyState === this.CLOSED) {
+      this._debug("close: already closed");
+      return;
+    }
+    this._ws.close(code, reason);
+  }
+
+  /**
+   * Closes the WebSocket connection or connection attempt and connects again.
+   * Resets retry counter;
+   */
+  public reconnect(code?: number, reason?: string) {
+    this._shouldReconnect = true;
+    this._closeCalled = false;
+    this._retryCount = -1;
+    if (!this._ws || this._ws.readyState === this.CLOSED) {
+      this._connect();
+    } else {
+      this._disconnect(code, reason);
+      this._connect();
+    }
+  }
+
+  /**
+   * Enqueue specified data to be transmitted to the server over the WebSocket connection
+   */
+  public send(data: Message) {
+    if (this._ws && this._ws.readyState === this.OPEN) {
+      this._debug("send", data);
+      this._ws.send(data);
+    } else {
+      const { maxEnqueuedMessages = DEFAULT.maxEnqueuedMessages } =
+        this._options;
+      if (this._messageQueue.length < maxEnqueuedMessages) {
+        this._debug("enqueue", data);
+        this._messageQueue.push(data);
+      }
+    }
+  }
+
+  /**
+   * Register an event handler of a specific event type
+   */
+  public addEventListener<T extends keyof Events.WebSocketEventListenerMap>(
+    type: T,
+    listener: Events.WebSocketEventListenerMap[T]
+  ): void {
+    if (this._listeners[type]) {
+      // @ts-expect-error we need to fix event/listerner types
+      this._listeners[type].push(listener);
+    }
+  }
+
+  public dispatchEvent(event: Event) {
+    const listeners =
+      this._listeners[event.type as keyof Events.WebSocketEventListenerMap];
+    if (listeners) {
+      for (const listener of listeners) {
+        this._callEventListener(event, listener);
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Removes an event listener
+   */
+  public removeEventListener<T extends keyof Events.WebSocketEventListenerMap>(
+    type: T,
+    listener: Events.WebSocketEventListenerMap[T]
+  ): void {
+    if (this._listeners[type]) {
+      // @ts-expect-error we need to fix event/listerner types
+      this._listeners[type] = this._listeners[type].filter(
+        // @ts-expect-error we need to fix event/listerner types
+        (l) => l !== listener
+      );
+    }
+  }
+
+  private _debug(...args: unknown[]) {
+    if (this._options.debug) {
+      // not using spread because compiled version uses Symbols
+      // tslint:disable-next-line
+      console.log.apply(console, ["RWS>", ...args]);
+    }
+  }
+
+  private _getNextDelay() {
+    const {
+      reconnectionDelayGrowFactor = DEFAULT.reconnectionDelayGrowFactor,
+      minReconnectionDelay = DEFAULT.minReconnectionDelay,
+      maxReconnectionDelay = DEFAULT.maxReconnectionDelay,
+    } = this._options;
+    let delay = 0;
+    if (this._retryCount > 0) {
+      delay =
+        minReconnectionDelay *
+        Math.pow(reconnectionDelayGrowFactor, this._retryCount - 1);
+      if (delay > maxReconnectionDelay) {
+        delay = maxReconnectionDelay;
+      }
+    }
+    this._debug("next delay", delay);
+    return delay;
+  }
+
+  private _wait(): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(resolve, this._getNextDelay());
+    });
+  }
+
+  private _getNextProtocols(
+    protocolsProvider: ProtocolsProvider | null
+  ): Promise<string | string[] | null> {
+    if (!protocolsProvider) return Promise.resolve(null);
+
+    if (
+      typeof protocolsProvider === "string" ||
+      Array.isArray(protocolsProvider)
+    ) {
+      return Promise.resolve(protocolsProvider);
+    }
+
+    if (typeof protocolsProvider === "function") {
+      const protocols = protocolsProvider();
+      if (!protocols) return Promise.resolve(null);
+
+      if (typeof protocols === "string" || Array.isArray(protocols)) {
+        return Promise.resolve(protocols);
+      }
+
+      // @ts-expect-error redundant check
+      if (protocols.then) {
+        return protocols;
+      }
+    }
+
+    throw Error("Invalid protocols");
+  }
+
+  private _getNextUrl(urlProvider: UrlProvider): Promise<string> {
+    if (typeof urlProvider === "string") {
+      return Promise.resolve(urlProvider);
+    }
+    if (typeof urlProvider === "function") {
+      const url = urlProvider();
+      if (typeof url === "string") {
+        return Promise.resolve(url);
+      }
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      if (url.then) {
+        return url;
+      }
+
+      // return url;
+    }
+    throw Error("Invalid URL");
+  }
+
+  private _connect() {
+    if (this._connectLock || !this._shouldReconnect) {
+      return;
+    }
+    this._connectLock = true;
+
+    const {
+      maxRetries = DEFAULT.maxRetries,
+      connectionTimeout = DEFAULT.connectionTimeout,
+    } = this._options;
+
+    if (this._retryCount >= maxRetries) {
+      this._debug("max retries reached", this._retryCount, ">=", maxRetries);
+      return;
+    }
+
+    this._retryCount++;
+
+    this._debug("connect", this._retryCount);
+    this._removeListeners();
+    if (!isWebSocket(WebSocket)) {
+      throw Error("No valid WebSocket class provided");
+    }
+    this._wait()
+      .then(() =>
+        Promise.all([
+          this._getNextUrl(this._url),
+          this._getNextProtocols(this._protocols || null),
+        ])
+      )
+      .then(([url, protocols]) => {
+        // close could be called before creating the ws
+        if (this._closeCalled) {
+          this._connectLock = false;
+          return;
+        }
+        this._debug("connect", { url, protocols });
+        this._ws = protocols
+          ? new WebSocket(url, protocols)
+          : new WebSocket(url);
+
+        this._ws.binaryType = this._binaryType;
+        this._connectLock = false;
+        this._addListeners();
+
+        this._connectTimeout = setTimeout(
+          () => this._handleTimeout(),
+          connectionTimeout
+        );
+      })
+      // via https://github.com/pladaria/reconnecting-websocket/pull/166
+      .catch((err) => {
+        this._connectLock = false;
+        this._handleError(new Events.ErrorEvent(Error(err.message), this));
+      });
+  }
+
+  private _handleTimeout() {
+    this._debug("timeout event");
+    this._handleError(new Events.ErrorEvent(Error("TIMEOUT"), this));
+  }
+
+  private _disconnect(code = 1000, reason?: string) {
+    this._clearTimeouts();
+    if (!this._ws) {
+      return;
+    }
+    this._removeListeners();
+    try {
+      this._ws.close(code, reason);
+      this._handleClose(new Events.CloseEvent(code, reason, this));
+    } catch (error) {
+      // ignore
+    }
+  }
+
+  private _acceptOpen() {
+    this._debug("accept open");
+    this._retryCount = 0;
+  }
+
+  private _callEventListener<T extends keyof Events.WebSocketEventListenerMap>(
+    event: Events.WebSocketEventMap[T],
+    listener: Events.WebSocketEventListenerMap[T]
+  ) {
+    if ("handleEvent" in listener) {
+      // @ts-expect-error we need to fix event/listerner types
+      listener.handleEvent(event);
+    } else {
+      // @ts-expect-error we need to fix event/listerner types
+      listener(event);
+    }
+  }
+
+  private _handleOpen = (event: Event) => {
+    this._debug("open event");
+    const { minUptime = DEFAULT.minUptime } = this._options;
+
+    clearTimeout(this._connectTimeout);
+    this._uptimeTimeout = setTimeout(() => this._acceptOpen(), minUptime);
+
+    assert(this._ws, "WebSocket is not defined");
+
+    this._ws.binaryType = this._binaryType;
+
+    // send enqueued messages (messages sent before websocket open event)
+    this._messageQueue.forEach((message) => this._ws?.send(message));
+    this._messageQueue = [];
+
+    if (this.onopen) {
+      this.onopen(event);
+    }
+    this._listeners.open.forEach((listener) =>
+      this._callEventListener(event, listener)
+    );
+  };
+
+  private _handleMessage = (event: MessageEvent) => {
+    this._debug("message event");
+
+    if (this.onmessage) {
+      this.onmessage(event);
+    }
+    this._listeners.message.forEach((listener) =>
+      this._callEventListener(event, listener)
+    );
+  };
+
+  private _handleError = (event: Events.ErrorEvent) => {
+    this._debug("error event", event.message);
+    this._disconnect(
+      undefined,
+      event.message === "TIMEOUT" ? "timeout" : undefined
+    );
+
+    if (this.onerror) {
+      this.onerror(event);
+    }
+    this._debug("exec error listeners");
+    this._listeners.error.forEach((listener) =>
+      this._callEventListener(event, listener)
+    );
+
+    this._connect();
+  };
+
+  private _handleClose = (event: Events.CloseEvent) => {
+    this._debug("close event");
+    this._clearTimeouts();
+
+    if (this._shouldReconnect) {
+      this._connect();
+    }
+
+    if (this.onclose) {
+      this.onclose(event);
+    }
+    this._listeners.close.forEach((listener) =>
+      this._callEventListener(event, listener)
+    );
+  };
+
+  private _removeListeners() {
+    if (!this._ws) {
+      return;
+    }
+    this._debug("removeListeners");
+    this._ws.removeEventListener("open", this._handleOpen);
+    this._ws.removeEventListener("close", this._handleClose);
+    this._ws.removeEventListener("message", this._handleMessage);
+    // @ts-expect-error we need to fix event/listerner types
+    this._ws.removeEventListener("error", this._handleError);
+  }
+
+  private _addListeners() {
+    if (!this._ws) {
+      return;
+    }
+    this._debug("addListeners");
+    this._ws.addEventListener("open", this._handleOpen);
+    this._ws.addEventListener("close", this._handleClose);
+    this._ws.addEventListener("message", this._handleMessage);
+    // @ts-expect-error we need to fix event/listerner types
+    this._ws.addEventListener("error", this._handleError);
+  }
+
+  private _clearTimeouts() {
+    clearTimeout(this._connectTimeout);
+    clearTimeout(this._uptimeTimeout);
+  }
+}

--- a/packages/partysocket/src/tests/fixture.js
+++ b/packages/partysocket/src/tests/fixture.js
@@ -1,0 +1,11 @@
+export default {
+  onConnect(ws, _room) {
+    ws.onmessage = function incoming(evt) {
+      if (evt.data === "ping") {
+        ws.send("pong");
+      } else {
+        ws.send("unknown");
+      }
+    };
+  },
+};

--- a/packages/partysocket/src/tests/index.test.ts
+++ b/packages/partysocket/src/tests/index.test.ts
@@ -2,8 +2,8 @@
  * @vitest-environment jsdom
  */
 import { describe, it, afterEach } from "vitest";
-import { dev } from "../cli";
-import { PartySocket } from "../client";
+import { dev } from "partykit/src/cli";
+import PartySocket from "..";
 
 // jsdom doesn't appear to have crypto.randomUUID
 import crypto from "crypto";

--- a/packages/partysocket/src/tests/reconnecting.flaky-test.ts
+++ b/packages/partysocket/src/tests/reconnecting.flaky-test.ts
@@ -1,0 +1,949 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-explicit-any */
+import { beforeEach, afterEach, test, expect, vitest } from "vitest";
+import WebSocket from "ws";
+import type { ErrorEvent } from "../reconnecting-websocket";
+import ReconnectingWebSocket from "../reconnecting-websocket";
+import { spawn } from "child_process";
+const WebSocketServer = WebSocket.Server;
+
+const PORT = 50123;
+const PORT_UNRESPONSIVE = "50124";
+const URL = `ws://localhost:${PORT}`;
+
+beforeEach(() => {
+  (global as any).WebSocket = WebSocket;
+});
+
+afterEach(() => {
+  delete (global as any).WebSocket;
+  vitest.restoreAllMocks();
+});
+
+// test("throws with invalid constructor", () => {
+//   delete (global as any).WebSocket;
+//   expect(() => {
+//     new ReconnectingWebSocket(URL, undefined, {
+//       // @ts-expect-error we're purposefully passing an invalid constructor
+//       WebSocket: 123,
+//       maxRetries: 0,
+//     });
+//   }).toThrow();
+// });
+
+test("throws with missing constructor", () => {
+  delete (global as any).WebSocket;
+  expect(() => {
+    new ReconnectingWebSocket(URL, undefined, { maxRetries: 0 });
+  }).toThrow();
+});
+
+test("throws with non-constructor object", () => {
+  (global as any).WebSocket = {};
+  expect(() => {
+    new ReconnectingWebSocket(URL, undefined, { maxRetries: 0 });
+  }).toThrow();
+});
+
+test("throws if not created with `new`", () => {
+  expect(() => {
+    // @ts-ignore
+    ReconnectingWebSocket(URL, undefined);
+  }).toThrow(TypeError);
+});
+
+function toPromise(fn: (resolve: () => void) => void) {
+  return () =>
+    new Promise<void>((resolve) => {
+      fn(resolve);
+    });
+}
+
+function testDone(name: string, fn: (resolve: () => void) => void) {
+  test(name, toPromise(fn));
+}
+
+testDone("global WebSocket is used if available", (done) => {
+  // @ts-ignore
+  const ws = new ReconnectingWebSocket(URL, undefined, { maxRetries: 0 });
+  ws.onerror = () => {
+    // @ts-ignore
+    expect(ws._ws instanceof WebSocket).toBe(true);
+    done();
+  };
+});
+
+testDone("getters when not ready", (done) => {
+  const ws = new ReconnectingWebSocket(URL, undefined, {
+    maxRetries: 0,
+  });
+  expect(ws.bufferedAmount).toBe(0);
+  expect(ws.protocol).toBe("");
+  expect(ws.url).toBe("");
+  expect(ws.extensions).toBe("");
+  expect(ws.binaryType).toBe("blob");
+
+  ws.onerror = () => {
+    done();
+  };
+});
+
+testDone("debug on", (done) => {
+  const logSpy = vitest.spyOn(console, "log").mockReturnValue();
+
+  const ws = new ReconnectingWebSocket(URL, undefined, {
+    maxRetries: 0,
+    debug: true,
+  });
+
+  ws.onerror = () => {
+    expect(logSpy).toHaveBeenCalledWith("RWS>", "connect", 0);
+    done();
+  };
+});
+
+testDone("debug off", (done) => {
+  const logSpy = vitest.spyOn(console, "log").mockReturnValue();
+
+  const ws = new ReconnectingWebSocket(URL, undefined, { maxRetries: 0 });
+
+  ws.onerror = () => {
+    expect(logSpy).not.toHaveBeenCalled();
+    done();
+  };
+});
+
+// testDone("pass WebSocket via options", (done) => {
+//   delete (global as any).WebSocket;
+//   const ws = new ReconnectingWebSocket(URL, undefined, {
+//     WebSocket,
+//     maxRetries: 0,
+//   });
+//   ws.onerror = () => {
+//     // @ts-ignore - accessing private property
+//     expect(ws._ws instanceof WebSocket).toBe(true);
+//     done();
+//   };
+// });
+
+test("URL provider", async () => {
+  const url = "example.com";
+  const ws = new ReconnectingWebSocket(URL, undefined, { maxRetries: 0 });
+
+  // @ts-ignore - accessing private property
+  expect(await ws._getNextUrl(url)).toBe(url);
+
+  // @ts-ignore - accessing private property
+  expect(await ws._getNextUrl(() => url)).toBe(url);
+
+  // @ts-ignore - accessing private property
+  expect(await ws._getNextUrl(() => Promise.resolve(url))).toBe(url);
+
+  // @ts-ignore - accessing private property
+  expect(() => ws._getNextUrl(123)).toThrow();
+
+  // @ts-ignore - accessing private property
+  expect(() => ws._getNextUrl(() => 123)).toThrow();
+});
+
+testDone("websocket protocol", (done) => {
+  const anyProtocol = "foobar";
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, anyProtocol);
+
+  ws.addEventListener("open", () => {
+    expect(ws.url).toBe(URL);
+    expect(ws.protocol).toBe(anyProtocol);
+    ws.close();
+  });
+
+  ws.addEventListener("close", () => {
+    wss.close(() => {
+      setTimeout(done, 500);
+    });
+  });
+});
+
+testDone("undefined websocket protocol", (done) => {
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, undefined, {});
+
+  ws.addEventListener("open", () => {
+    expect(ws.url).toBe(URL);
+    expect(ws.protocol).toBe("");
+    ws.close();
+  });
+
+  ws.addEventListener("close", () => {
+    wss.close(() => {
+      setTimeout(done, 500);
+    });
+  });
+});
+
+testDone("null websocket protocol", (done) => {
+  const wss = new WebSocketServer({ port: PORT });
+
+  // @ts-ignore - null is not allowed but could be passed in vanilla js
+  const ws = new ReconnectingWebSocket(URL, null, {});
+  ws.addEventListener("open", () => {
+    expect(ws.url).toBe(URL);
+    expect(ws.protocol).toBe("");
+    ws.close();
+  });
+
+  ws.addEventListener("close", () => {
+    wss.close(() => {
+      setTimeout(done, 100);
+    });
+  });
+});
+
+test("websocket invalid protocolsProvider", () => {
+  const ws = new ReconnectingWebSocket("ws://example.com", "foo", {});
+
+  // @ts-ignore - accessing private property
+  expect(() => ws._getNextProtocols(() => /Hahaha/)).toThrow();
+});
+
+testDone("websocket sync protocolsProvider", (done) => {
+  const anyProtocol = "bar";
+  const wss = new WebSocketServer({ port: PORT });
+
+  const ws = new ReconnectingWebSocket(URL, () => anyProtocol, {});
+  ws.addEventListener("open", () => {
+    expect(ws.url).toBe(URL);
+    expect(ws.protocol).toBe(anyProtocol);
+    ws.close();
+  });
+
+  ws.addEventListener("close", () => {
+    wss.close(() => setTimeout(done, 100));
+  });
+});
+
+testDone("websocket async protocolsProvider", (done) => {
+  const anyProtocol = "foo";
+  const wss = new WebSocketServer({ port: PORT });
+
+  const ws = new ReconnectingWebSocket(URL, async () => anyProtocol, {});
+  ws.addEventListener("open", () => {
+    expect(ws.url).toBe(URL);
+    expect(ws.protocol).toBe(anyProtocol);
+    ws.close();
+  });
+
+  ws.addEventListener("close", () => {
+    wss.close(() => setTimeout(done, 100));
+  });
+});
+
+test("connection status constants", () => {
+  const ws = new ReconnectingWebSocket(URL, undefined, { maxRetries: 0 });
+
+  expect(ReconnectingWebSocket.CONNECTING).toBe(0);
+  expect(ReconnectingWebSocket.OPEN).toBe(1);
+  expect(ReconnectingWebSocket.CLOSING).toBe(2);
+  expect(ReconnectingWebSocket.CLOSED).toBe(3);
+
+  expect(ws.CONNECTING).toBe(0);
+  expect(ws.OPEN).toBe(1);
+  expect(ws.CLOSING).toBe(2);
+  expect(ws.CLOSED).toBe(3);
+  ws.close();
+});
+
+const maxRetriesTest = (count: number, done: () => void) => {
+  const ws = new ReconnectingWebSocket(URL, undefined, {
+    maxRetries: count,
+    maxReconnectionDelay: 200,
+  });
+
+  ws.addEventListener("error", () => {
+    if (ws.retryCount === count) {
+      setTimeout(done, 500);
+    }
+    if (ws.retryCount > count) {
+      throw Error(`too many retries: ${ws.retryCount}`);
+    }
+  });
+};
+
+testDone("max retries: 0", (done) => maxRetriesTest(0, done));
+testDone("max retries: 1", (done) => maxRetriesTest(1, done));
+testDone("max retries: 5", (done) => maxRetriesTest(5, done));
+
+testDone("level0 event listeners are kept after reconnect", (done) => {
+  const ws = new ReconnectingWebSocket(URL, undefined, {
+    maxRetries: 4,
+    reconnectionDelayGrowFactor: 1.2,
+    maxReconnectionDelay: 20,
+    minReconnectionDelay: 10,
+  });
+
+  const handleOpen = () => undefined;
+  const handleClose = () => undefined;
+  const handleMessage = () => undefined;
+  const handleError = () => {
+    expect(ws.onopen).toBe(handleOpen);
+    expect(ws.onclose).toBe(handleClose);
+    expect(ws.onmessage).toBe(handleMessage);
+    expect(ws.onerror).toBe(handleError);
+    if (ws.retryCount === 4) {
+      done();
+    }
+  };
+
+  ws.onopen = handleOpen;
+  ws.onclose = handleClose;
+  ws.onmessage = handleMessage;
+  ws.onerror = handleError;
+});
+
+testDone("level2 event listeners", (done) => {
+  const anyProtocol = "foobar";
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, anyProtocol, {});
+
+  ws.addEventListener("open", () => {
+    expect(ws.protocol).toBe(anyProtocol);
+    expect(ws.extensions).toBe("");
+    expect(ws.bufferedAmount).toBe(0);
+    ws.close();
+  });
+
+  const fail = () => {
+    throw Error("fail");
+  };
+  // @ts-ignore
+  ws.addEventListener("unknown1", fail);
+  ws.addEventListener("open", fail);
+  ws.addEventListener("open", fail);
+  ws.removeEventListener("open", fail);
+  // @ts-ignore
+  ws.removeEventListener("unknown2", fail);
+
+  ws.addEventListener("close", () => {
+    wss.close(() => {
+      setTimeout(() => done(), 500);
+    });
+  });
+});
+
+// https://developer.mozilla.org/en-US/docs/Web/API/EventListener/handleEvent
+testDone("level2 event listeners using object with handleEvent", (done) => {
+  const anyProtocol = "foobar";
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, anyProtocol, {});
+
+  ws.addEventListener("open", {
+    // @ts-ignore
+    handleEvent: () => {
+      expect(ws.protocol).toBe(anyProtocol);
+      expect(ws.extensions).toBe("");
+      expect(ws.bufferedAmount).toBe(0);
+      ws.close();
+    },
+  });
+
+  const fail = {
+    handleEvent: () => {
+      throw Error("fail");
+    },
+  };
+  // @ts-ignore
+  ws.addEventListener("unknown1", fail);
+  // @ts-ignore
+  ws.addEventListener("open", fail);
+  // @ts-ignore
+  ws.addEventListener("open", fail);
+  // @ts-ignore
+  ws.removeEventListener("open", fail);
+  // @ts-ignore
+  ws.removeEventListener("unknown2", fail);
+
+  // @ts-ignore
+  ws.addEventListener("close", {
+    // @ts-ignore
+    handleEvent: () => {
+      wss.close();
+      setTimeout(() => done(), 500);
+    },
+  });
+});
+
+testDone("connection timeout", (done) => {
+  const proc = spawn("node", [
+    `${__dirname}/unresponsive-server.js`,
+    PORT_UNRESPONSIVE,
+    "5000",
+  ]);
+
+  let lock = false;
+  proc.stdout.on("data", () => {
+    if (lock) return;
+    lock = true;
+
+    const ws = new ReconnectingWebSocket(
+      `ws://localhost:${PORT_UNRESPONSIVE}`,
+      undefined,
+      {
+        minReconnectionDelay: 50,
+        connectionTimeout: 500,
+        maxRetries: 1,
+      }
+    );
+
+    ws.addEventListener("error", (event) => {
+      expect(event.message).toBe("TIMEOUT");
+      if (ws.retryCount === 1) {
+        setTimeout(() => done(), 1000);
+      }
+    });
+  });
+});
+
+testDone("getters", (done) => {
+  const anyProtocol = "foobar";
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, anyProtocol, {
+    maxReconnectionDelay: 100,
+  });
+
+  ws.addEventListener("open", () => {
+    expect(ws.protocol).toBe(anyProtocol);
+    expect(ws.extensions).toBe("");
+    expect(ws.bufferedAmount).toBe(0);
+    expect(ws.binaryType).toBe("nodebuffer");
+    ws.close();
+  });
+
+  ws.addEventListener("close", () => {
+    wss.close();
+    setTimeout(() => done(), 500);
+  });
+});
+
+testDone("binaryType", (done) => {
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, undefined, {
+    minReconnectionDelay: 0,
+  });
+
+  expect(ws.binaryType).toBe("blob");
+  ws.binaryType = "arraybuffer";
+  ws.addEventListener("open", () => {
+    expect(ws.binaryType).toBe("arraybuffer");
+    // @ts-ignore
+    ws.binaryType = "nodebuffer";
+    expect(ws.binaryType).toBe("nodebuffer");
+    ws.close();
+  });
+
+  ws.addEventListener("close", () => {
+    wss.close();
+    setTimeout(() => done(), 500);
+  });
+});
+
+testDone("calling to close multiple times", (done) => {
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, undefined, {});
+
+  ws.addEventListener("open", () => {
+    ws.close();
+    ws.close();
+    ws.close();
+  });
+
+  ws.addEventListener("close", () => {
+    wss.close();
+    setTimeout(() => done(), 500);
+  });
+});
+
+testDone("calling to reconnect when not ready", (done) => {
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, undefined, {});
+  ws.reconnect();
+  ws.reconnect();
+
+  ws.addEventListener("open", () => {
+    ws.close();
+  });
+
+  ws.addEventListener("close", () => {
+    wss.close();
+    setTimeout(() => done(), 500);
+  });
+});
+
+testDone("start closed", (done) => {
+  const anyMessageText = "hello";
+  const anyProtocol = "foobar";
+
+  const wss = new WebSocketServer({ port: PORT });
+  wss.on("connection", (ws: WebSocket) => {
+    ws.on("message", (msg: WebSocket.Data) => {
+      ws.send(msg);
+    });
+  });
+  wss.on("error", () => {
+    throw Error("error");
+  });
+
+  expect.assertions(8);
+
+  const ws = new ReconnectingWebSocket(URL, anyProtocol, {
+    minReconnectionDelay: 100,
+    maxReconnectionDelay: 200,
+    startClosed: true,
+  });
+
+  expect(ws.readyState).toBe(ws.CLOSED);
+
+  setTimeout(() => {
+    expect(ws.readyState).toBe(ws.CLOSED);
+
+    ws.reconnect();
+
+    ws.addEventListener("open", () => {
+      expect(ws.protocol).toBe(anyProtocol);
+      expect(ws.readyState).toBe(ws.OPEN);
+      ws.send(anyMessageText);
+    });
+
+    ws.addEventListener("message", (msg) => {
+      expect(msg.data).toBe(anyMessageText);
+      ws.close(1000, "");
+      expect(ws.readyState).toBe(ws.CLOSING);
+    });
+
+    ws.addEventListener("close", () => {
+      expect(ws.readyState).toBe(ws.CLOSED);
+      expect(ws.url).toBe(URL);
+      wss.close();
+      setTimeout(() => done(), 1000);
+    });
+  }, 300);
+});
+
+testDone("connect, send, receive, close", (done) => {
+  const anyMessageText = "hello";
+  const anyProtocol = "foobar";
+
+  const wss = new WebSocketServer({ port: PORT });
+  wss.on("connection", (ws: WebSocket) => {
+    ws.on("message", (msg: WebSocket.Data) => {
+      ws.send(msg);
+    });
+  });
+  wss.on("error", () => {
+    throw Error("error");
+  });
+
+  expect.assertions(7);
+
+  const ws = new ReconnectingWebSocket(URL, anyProtocol, {
+    minReconnectionDelay: 100,
+    maxReconnectionDelay: 200,
+  });
+  expect(ws.readyState).toBe(ws.CONNECTING);
+
+  ws.addEventListener("open", () => {
+    expect(ws.protocol).toBe(anyProtocol);
+    expect(ws.readyState).toBe(ws.OPEN);
+    ws.send(anyMessageText);
+  });
+
+  ws.addEventListener("message", (msg) => {
+    expect(msg.data).toBe(anyMessageText);
+    ws.close(1000, "");
+    expect(ws.readyState).toBe(ws.CLOSING);
+  });
+
+  ws.addEventListener("close", () => {
+    expect(ws.readyState).toBe(ws.CLOSED);
+    expect(ws.url).toBe(URL);
+    wss.close();
+    setTimeout(() => done(), 1000);
+  });
+});
+
+testDone("connect, send, receive, reconnect", (done) => {
+  const anyMessageText = "hello";
+  const anyProtocol = "foobar";
+
+  const wss = new WebSocketServer({ port: PORT });
+  wss.on("connection", (ws: WebSocket) => {
+    ws.on("message", (msg: WebSocket.Data) => {
+      ws.send(msg);
+    });
+  });
+
+  const totalRounds = 3;
+  let currentRound = 0;
+
+  // 6 = 3 * 2 open
+  // 8 = 2 * 3 message + 2 reconnect
+  // 7 = 2 * 3 close + 1 closed
+  expect.assertions(21);
+
+  const ws = new ReconnectingWebSocket(URL, anyProtocol, {
+    minReconnectionDelay: 100,
+    maxReconnectionDelay: 200,
+  });
+
+  ws.onopen = () => {
+    currentRound++;
+    expect(ws.protocol).toBe(anyProtocol);
+    expect(ws.readyState).toBe(ws.OPEN);
+    ws.send(anyMessageText);
+  };
+
+  ws.onmessage = (msg) => {
+    expect(msg.data).toBe(anyMessageText);
+    if (currentRound < totalRounds) {
+      ws.reconnect(1000, "reconnect");
+      expect(ws.retryCount).toBe(0);
+    } else {
+      ws.close(1000, "close");
+    }
+    expect(ws.readyState).toBe(ws.CLOSING);
+  };
+
+  ws.addEventListener("close", (event) => {
+    expect(ws.url).toBe(URL);
+    if (currentRound >= totalRounds) {
+      expect(ws.readyState).toBe(ws.CLOSED);
+      wss.close();
+      setTimeout(() => done(), 1000);
+      expect(event.reason).toBe("close");
+    } else {
+      expect(event.reason).toBe("reconnect");
+    }
+  });
+});
+
+testDone("immediately-failed connection should not timeout", (done) => {
+  const ws = new ReconnectingWebSocket("ws://255.255.255.255", undefined, {
+    maxRetries: 2,
+    connectionTimeout: 500,
+  });
+
+  ws.addEventListener("error", (err: ErrorEvent) => {
+    if (err.message === "TIMEOUT") {
+      throw Error("error");
+    }
+    if (ws.retryCount === 2) {
+      setTimeout(() => done(), 500);
+    }
+    if (ws.retryCount > 2) {
+      throw Error("error");
+    }
+  });
+});
+
+testDone(
+  "immediately-failed connection with 0 maxRetries must not retry",
+  (done) => {
+    const ws = new ReconnectingWebSocket("ws://255.255.255.255", [], {
+      maxRetries: 0,
+      connectionTimeout: 2000,
+      minReconnectionDelay: 100,
+      maxReconnectionDelay: 200,
+    });
+
+    let i = 0;
+    ws.addEventListener("error", (err) => {
+      i++;
+      if (err.message === "TIMEOUT") {
+        throw Error("error");
+      }
+      if (i > 1) {
+        throw Error("error");
+      }
+      setTimeout(() => {
+        done();
+      }, 2100);
+    });
+  }
+);
+
+testDone("connect and close before establishing connection", (done) => {
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, undefined, {
+    minReconnectionDelay: 100,
+    maxReconnectionDelay: 200,
+  });
+
+  ws.close(); // closing before establishing connection
+
+  ws.addEventListener("open", () => {
+    throw Error("open called");
+  });
+
+  let closeCount = 0;
+  ws.addEventListener("close", () => {
+    closeCount++;
+    if (closeCount > 1) {
+      throw Error("close should be called once");
+    }
+  });
+
+  setTimeout(() => {
+    // wait a little to be sure no unexpected open or close events happen
+    wss.close();
+    done();
+  }, 1000);
+});
+
+testDone("enqueue messages", (done) => {
+  const ws = new ReconnectingWebSocket(URL, undefined, {
+    maxRetries: 0,
+  });
+  const count = 10;
+  const message = "message";
+  for (let i = 0; i < count; i++) ws.send(message);
+
+  ws.onerror = () => {
+    expect(ws.bufferedAmount).toBe(message.length * count);
+    done();
+  };
+});
+
+testDone("respect maximum enqueued messages", (done) => {
+  const queueSize = 2;
+  const ws = new ReconnectingWebSocket(URL, undefined, {
+    maxRetries: 0,
+    maxEnqueuedMessages: queueSize,
+  });
+  const count = 10;
+  const message = "message";
+  for (let i = 0; i < count; i++) ws.send(message);
+
+  ws.onerror = () => {
+    expect(ws.bufferedAmount).toBe(message.length * queueSize);
+    done();
+  };
+});
+
+testDone(
+  "enqueue messages before websocket initialization with expected order",
+  (done) => {
+    const wss = new WebSocketServer({ port: PORT });
+    const ws = new ReconnectingWebSocket(URL);
+
+    const messages = ["message1", "message2", "message3"];
+
+    messages.forEach((m) => ws.send(m));
+    // @ts-ignore - accessing private field
+    expect(ws._messageQueue.length).toBe(messages.length);
+
+    expect(ws.bufferedAmount).toBe(messages.reduce((a, m) => a + m.length, 0));
+
+    let i = 0;
+    wss.on("connection", (client: WebSocket) => {
+      client.on("message", (data: WebSocket.Data) => {
+        if (data === "ok") {
+          expect(i).toBe(messages.length);
+          ws.close();
+        } else {
+          expect(data).toBe(messages[i]);
+          i++;
+        }
+      });
+    });
+
+    ws.addEventListener("open", () => {
+      ws.send("ok");
+    });
+
+    ws.addEventListener("close", () => {
+      wss.close(() => {
+        done();
+      });
+    });
+  }
+);
+
+testDone("closing from the other side should reconnect", (done) => {
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, undefined, {
+    minReconnectionDelay: 100,
+    maxReconnectionDelay: 200,
+  });
+
+  const max = 3;
+  let i = 0;
+  wss.on("connection", (client: WebSocket) => {
+    i++;
+    if (i < max) {
+      // closing client from server side should trigger a reconnection
+      setTimeout(() => client.close(), 100);
+    }
+    if (i === max) {
+      // will close from client side
+    }
+    if (i > max) {
+      throw Error("unexpected connection");
+    }
+  });
+
+  let j = 0;
+  ws.addEventListener("open", () => {
+    j++;
+    if (j === max) {
+      ws.close();
+      // wait a little to ensure no new connections are opened
+      setTimeout(() => {
+        wss.close(() => {
+          done();
+        });
+      }, 500);
+    }
+    if (j > max) {
+      throw Error("unexpected open");
+    }
+  });
+});
+
+testDone("closing from the other side should allow to keep closed", (done) => {
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, undefined, {
+    minReconnectionDelay: 100,
+    maxReconnectionDelay: 200,
+  });
+
+  const codes = [4000, 4001];
+
+  let i = 0;
+  wss.on("connection", (client: WebSocket) => {
+    if (i > codes.length) {
+      throw Error("error");
+    }
+    client.close(codes[i], String(codes[i]));
+    i++;
+  });
+
+  ws.addEventListener("close", (e) => {
+    if (e.code === codes[0]) {
+      // do nothing, will reconnect
+    }
+    if (e.code === codes[1] && e.reason === String(codes[1])) {
+      // close connection (and keep closed)
+      ws.close();
+      setTimeout(() => {
+        wss.close(() => done());
+      }, 1000);
+    }
+  });
+});
+
+testDone("reconnection delay grow factor", (done) => {
+  const ws = new ReconnectingWebSocket("wss://255.255.255.255", [], {
+    minReconnectionDelay: 100,
+    maxReconnectionDelay: 1000,
+    reconnectionDelayGrowFactor: 2,
+  });
+  // @ts-ignore - accessing private field
+  expect(ws._getNextDelay()).toBe(0);
+  const expected = [100, 200, 400, 800, 1000, 1000];
+  let retry = 0;
+  ws.addEventListener("error", () => {
+    // @ts-ignore - accessing private field
+    expect(ws._getNextDelay()).toBe(expected[retry]);
+    retry++;
+    if (retry >= expected.length) {
+      ws.close();
+      setTimeout(() => {
+        done();
+      }, 2000);
+    }
+  });
+});
+
+testDone("minUptime", (done) => {
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, [], {
+    minReconnectionDelay: 100,
+    maxReconnectionDelay: 2000,
+    reconnectionDelayGrowFactor: 2,
+    minUptime: 500,
+  });
+  const expectedDelays = [100, 200, 400, 800, 100, 100];
+  const expectedRetryCount = [1, 2, 3, 4, 1, 1];
+  let connectionCount = 0;
+  wss.on("connection", (client: WebSocket) => {
+    connectionCount++;
+    if (connectionCount <= expectedDelays.length) {
+      setTimeout(() => {
+        client.close();
+      }, connectionCount * 100);
+    }
+  });
+  let openCount = 0;
+  ws.addEventListener("open", () => {
+    openCount++;
+    if (openCount > expectedDelays.length) {
+      ws.close();
+      wss.close(() => {
+        setTimeout(() => {
+          done();
+        }, 1000);
+      });
+    }
+  });
+  let closeCount = 0;
+  ws.addEventListener("close", () => {
+    if (closeCount < expectedDelays.length) {
+      // @ts-ignore - accessing private field
+      expect(ws._getNextDelay()).toBe(expectedDelays[closeCount]);
+      // @ts-ignore - accessing private field
+      expect(ws._retryCount).toBe(expectedRetryCount[closeCount]);
+      closeCount++;
+    }
+  });
+});
+
+testDone("reconnect after closing", (done) => {
+  const wss = new WebSocketServer({ port: PORT });
+  const ws = new ReconnectingWebSocket(URL, undefined, {
+    minReconnectionDelay: 100,
+    maxReconnectionDelay: 200,
+  });
+
+  let i = 0;
+  ws.addEventListener("open", () => {
+    i++;
+    if (i === 1) {
+      ws.close();
+    }
+    if (i === 2) {
+      ws.close();
+    }
+    if (i > 2) {
+      throw Error("no more expected reconnections");
+    }
+  });
+
+  ws.addEventListener("close", () => {
+    if (i === 1)
+      setTimeout(() => {
+        ws.reconnect();
+      }, 1000);
+    if (i === 2) {
+      wss.close(() => {
+        setTimeout(() => {
+          done();
+        }, 1000);
+      });
+    }
+    if (i > 2) {
+      throw Error("no more expected reconnections");
+    }
+  });
+});

--- a/packages/partysocket/tsconfig.extract.json
+++ b/packages/partysocket/tsconfig.extract.json
@@ -1,0 +1,13 @@
+// only used during builds to extract .d.ts files
+
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src/index.ts"],
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "./dist"
+  }
+}

--- a/packages/partysocket/tsconfig.json
+++ b/packages/partysocket/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.base.json"
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     reporters: ["verbose"],
     threads: false,
-    testTimeout: 1000,
+    testTimeout: 5000,
     setupFiles: ["./vitest.setup.js"],
   },
 });


### PR DESCRIPTION
This forks `reconnecting-websocket` into our own package, and adds some functionality from abandoned PRs on the source repo. Of note:
- https://github.com/pladaria/reconnecting-websocket/pull/166 Fix: handle error if getNextUrl throws
- https://github.com/pladaria/reconnecting-websocket/pull/132 feat: make protocols updatable
- https://github.com/pladaria/reconnecting-websocket/pull/141 [Fix] Socket doesn't connect again after closing while connecting

(TODO: more)
- https://github.com/pladaria/reconnecting-websocket/pull/163 Support for Dynamic Protocols
- https://github.com/pladaria/reconnecting-websocket/pull/47 reconnecting and reconnectscheduled custom events