### PR TITLE
feat: persistence / storage (phase 1)

### DIFF
--- a/.changeset/light-llamas-hear.md
+++ b/.changeset/light-llamas-hear.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+feat: persistence / storage (phase 1)
+
+This implements persistence / storage for partykit. It hijack's cloudflare's DO storage api (without config options). This doesn't implement DO's i/o gates yet, but that's kinda fine, because it means you have to write code that's good in dev (but production will automatically be better). We'll implement them later. Also this currently does in-memory storage. We'll fix that in the future by (optionally) using disk for persistence.

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -7,18 +7,11 @@ import type { WebSocketServer } from "ws";
 // this is a node type, careful
 import type { IncomingMessage } from "http";
 
+import type { PartyKitServer, PartyKitRoom } from "../src/server";
+
+declare const Worker: PartyKitServer;
 declare const wss: WebSocketServer;
-declare const partyRoom: {
-  id: string;
-  connections: Map<
-    string,
-    {
-      id: string;
-      socket: WebSocket;
-      unstable_initial: unknown;
-    }
-  >;
-};
+declare const partyRoom: PartyKitRoom;
 
 function assert(condition: unknown, msg?: string): asserts condition {
   if (!condition) {

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -6,13 +6,35 @@ export type PartyKitConnection = {
   unstable_initial: unknown;
 };
 
+export type PartyKitStorage = {
+  get<T = unknown>(key: string): Promise<T | undefined>;
+  get<T = unknown>(keys: string[]): Promise<Map<string, T>>;
+  list<T = unknown>(options?: {
+    start?: string;
+    startAfter?: string;
+    end?: string;
+    prefix?: string;
+    reverse?: boolean;
+    limit?: number;
+  }): Promise<Map<string, T>>;
+  put<T>(key: string, value: T): Promise<void>;
+  put<T>(entries: Record<string, T>): Promise<void>;
+  delete(key: string): Promise<boolean>;
+  delete(keys: string[]): Promise<number>;
+  deleteAll(): Promise<void>;
+  // getAlarm(): Promise<number | null>;
+  // setAlarm(scheduledTime: number | Date): Promise<void>;
+  // deleteAlarm(): Promise<void>;
+};
+
 export type PartyKitRoom = {
   id: string; // room id, usually a slug
   connections: Map<string, PartyKitConnection>;
   env: Record<string, string>; // use a .env file, or --var
+  storage: PartyKitStorage;
 };
 
-export type PartyKitServer = {
+export type PartyKitServer<Initial = unknown> = {
   onConnect: (ws: WebSocket, room: PartyKitRoom) => void;
-  onBeforeConnect?: (req: Request) => Promise<unknown>;
+  onBeforeConnect?: (req: Request) => Promise<Initial>;
 };


### PR DESCRIPTION
This implements persistence / storage for partykit. It hijack's cloudflare's DO storage api (without config options). This doesn't implement DO's i/o gates yet, but that's kinda fine, because it means you have to write code that's good in dev (but production will automatically be better). We'll implement them later. Also this currently does in-memory storage. We'll fix that in the future by (optionally) using disk for persistence.