### PR TITLE
fix: add key/value size limits for storage api

### DIFF
--- a/.changeset/young-bikes-walk.md
+++ b/.changeset/young-bikes-walk.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+fix: add key/value size limits for storage api
+
+This adds checks for size of key/values for the persistence api (mirroring DO's limits). (2kb keys. 128 kb values)


### PR DESCRIPTION
This adds checks for size of key/values for the persistence api (mirroring DO's limits). (2kb keys. 128 kb values)