### PR TITLE
[y-partykit] fix: write state to storage on connection close

### DIFF
--- a/.changeset/warm-kangaroos-happen.md
+++ b/.changeset/warm-kangaroos-happen.md
@@ -1,0 +1,7 @@
+---
+"y-partykit": patch
+---
+
+[y-partykit] fix: write state to storage on connection close
+
+we'd forgotten to implement `writeState()` so data wasn't being saved when everyone left a room. the fix is to implement, seems fine now.

--- a/packages/y-partykit/src/index.ts
+++ b/packages/y-partykit/src/index.ts
@@ -120,7 +120,8 @@ class WSSharedDoc extends Y.Doc {
   }
   async writeState() {
     assert(this.storage, "Storage not set");
-    // TODO: what should we put here ?
+    const newUpdates = Y.encodeStateAsUpdate(this);
+    await this.storage.storeUpdate(this.name, newUpdates);
   }
 }
 


### PR DESCRIPTION
we'd forgotten to implement `writeState()` so data wasn't being saved when everyone left a room. the fix is to implement, seems fine now.