### PR TITLE
y-partykit: remove document size limits

### DIFF
--- a/.changeset/red-clocks-try.md
+++ b/.changeset/red-clocks-try.md
@@ -1,0 +1,7 @@
+---
+"y-partykit": patch
+---
+
+y-partykit: remove document size limits
+
+By chunking values, we can workaround DO's 128 kb value size limit. This patch implements that, and adds a couple of tests too.

--- a/examples/lexical/src/client.tsx
+++ b/examples/lexical/src/client.tsx
@@ -11,9 +11,10 @@ import YPartyKitProvider from "y-partykit/provider";
 
 import { createRoot } from "react-dom/client";
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const root = createRoot(document.getElementById("root")!);
-root.render(<Editor />);
+declare const PARTYKIT_HOST: string | undefined;
+
+const partykitHost =
+  typeof PARTYKIT_HOST === "undefined" ? "localhost:1999" : PARTYKIT_HOST;
 
 function Editor() {
   const initialConfig = {
@@ -38,7 +39,11 @@ function Editor() {
           const doc = new Y.Doc();
           yjsDocMap.set(id, doc);
 
-          const provider = new YPartyKitProvider("localhost:1999", id, doc);
+          const provider = new YPartyKitProvider(
+            partykitHost || "localhost:1999",
+            id,
+            doc
+          );
 
           return provider;
         }}
@@ -47,3 +52,7 @@ function Editor() {
     </LexicalComposer>
   );
 }
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const root = createRoot(document.getElementById("root")!);
+root.render(<Editor />);

--- a/packages/partykit/src/cli.ts
+++ b/packages/partykit/src/cli.ts
@@ -44,7 +44,7 @@ const envPath = findConfig(".env");
 const envVars = envPath ? dotenv.parse(fs.readFileSync(envPath, "utf8")) : {};
 
 // TODO: this should probably persist across hot reloads
-class RoomStorage implements PartyKitStorage {
+export class RoomStorage implements PartyKitStorage {
   storage = new Map<string, Buffer>();
 
   async get<T = unknown>(key: string): Promise<T | undefined>;

--- a/packages/y-partykit/src/tests/storage.test.ts
+++ b/packages/y-partykit/src/tests/storage.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { levelGet, levelPut, getLevelBulkData } from "../storage";
+import { RoomStorage } from "partykit/src/cli";
+
+describe("storage layer", () => {
+  it("should be able to set and get", async () => {
+    const storage = new RoomStorage();
+    await levelPut(storage, ["v1_sv", "bar"], new Uint8Array([1, 2, 3]));
+    const foo = await levelGet(storage, ["v1_sv", "bar"]);
+    expect(foo).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it("should be able to set and get big values", async () => {
+    const storage = new RoomStorage();
+    const value = new Uint8Array(100000);
+    await levelPut(storage, ["v1_sv", "bar"], value);
+    const foo = await levelGet(storage, ["v1_sv", "bar"]);
+    expect(foo).toEqual(value);
+  });
+
+  it("should be able to set and get bulk", async () => {
+    const storage = new RoomStorage();
+    await levelPut(storage, ["v1_sv", "bar"], new Uint8Array([1, 2, 3]));
+    await levelPut(storage, ["v1_sv", "baz"], new Uint8Array([4, 5, 6]));
+    const foo = await getLevelBulkData(storage, {
+      gte: ["v1_sv", ""],
+      lt: ["v1_sv", "zzz"],
+      keys: true,
+      values: true,
+    });
+    expect(foo).toEqual([
+      {
+        key: ["v1_sv", "bar"],
+        value: new Uint8Array([1, 2, 3]),
+      },
+      {
+        key: ["v1_sv", "baz"],
+        value: new Uint8Array([4, 5, 6]),
+      },
+    ]);
+  });
+
+  it("should be able to set and get big bulk", async () => {
+    const storage = new RoomStorage();
+    const value = new Uint8Array(100000);
+    await levelPut(storage, ["v1_sv", "bar"], value);
+    await levelPut(storage, ["v1_sv", "baz"], value);
+    const foo = await getLevelBulkData(storage, {
+      gte: ["v1_sv", ""],
+      lt: ["v1_sv", "zzz"],
+      keys: true,
+      values: true,
+    });
+    expect(foo).toEqual([
+      {
+        key: ["v1_sv", "bar"],
+        value,
+      },
+      {
+        key: ["v1_sv", "baz"],
+        value,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
By chunking values, we can workaround DO's 128 kb value size limit. This patch implements that, and adds a couple of tests too.