### PR TITLE
fix: don't crash in some secure contexts

### DIFF
--- a/.changeset/slow-coins-divide.md
+++ b/.changeset/slow-coins-divide.md
@@ -1,0 +1,8 @@
+---
+"partysocket": patch
+"y-partykit": patch
+---
+
+fix: don't crash in some secure contexts
+
+This uses a weaker implementation to generate conneciton IDs if crypto.randomUUID() isn't available in the browser (re: https://github.com/WICG/uuid/issues/23) Fixes https://github.com/partykit/partykit/issues/53

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -92,5 +92,7 @@ wss.on("connection", (ws: WebSocket, request: IncomingMessage) => {
   ws.addEventListener("close", closeOrErrorListener);
   ws.addEventListener("error", closeOrErrorListener);
 
-  Worker.onConnect(ws, partyRoom);
+  Worker.onConnect(ws, partyRoom)?.catch((err) => {
+    console.error("failed to connect", err);
+  });
 });

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -35,6 +35,6 @@ export type PartyKitRoom = {
 };
 
 export type PartyKitServer<Initial = unknown> = {
-  onConnect: (ws: WebSocket, room: PartyKitRoom) => void;
-  onBeforeConnect?: (req: Request) => Promise<Initial>;
+  onConnect: (ws: WebSocket, room: PartyKitRoom) => void | Promise<void>;
+  onBeforeConnect?: (req: Request) => Initial | Promise<Initial>;
 };

--- a/packages/partysocket/src/index.ts
+++ b/packages/partysocket/src/index.ts
@@ -13,6 +13,32 @@ export type PartySocketOptions = Omit<
   // headers
 };
 
+function generateUUID(): string {
+  // Public Domain/MIT
+  if (crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  let d = new Date().getTime(); //Timestamp
+  let d2 =
+    (typeof performance !== "undefined" &&
+      performance.now &&
+      performance.now() * 1000) ||
+    0; //Time in microseconds since page-load or 0 if unsupported
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+    let r = Math.random() * 16; //random number between 0 and 16
+    if (d > 0) {
+      //Use timestamp until depleted
+      r = (d + r) % 16 | 0;
+      d = Math.floor(d / 16);
+    } else {
+      //Use microseconds since page-load if supported
+      r = (d2 + r) % 16 | 0;
+      d2 = Math.floor(d2 / 16);
+    }
+    return (c === "x" ? r : (r & 0x3) | 0x8).toString(16);
+  });
+}
+
 // things that nathanboktae/robust-websocket claims are better:
 // doesn't do anything in offline mode (?)
 // "natively aware of error codes"
@@ -25,7 +51,7 @@ export default class PartySocket extends ReconnectingWebSocket {
   constructor(readonly partySocketOptions: PartySocketOptions) {
     const { host, room, protocol, query, protocols, ...socketOptions } =
       partySocketOptions;
-    const _pk = crypto.randomUUID();
+    const _pk = generateUUID();
     let url = `${
       protocol ||
       (host.startsWith("localhost:") || host.startsWith("127.0.0.1:")

--- a/packages/y-partykit/src/provider.ts
+++ b/packages/y-partykit/src/provider.ts
@@ -1,6 +1,32 @@
 import { WebsocketProvider } from "y-websocket";
 import type * as Y from "yjs";
 
+function generateUUID(): string {
+  // Public Domain/MIT
+  if (crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  let d = new Date().getTime(); //Timestamp
+  let d2 =
+    (typeof performance !== "undefined" &&
+      performance.now &&
+      performance.now() * 1000) ||
+    0; //Time in microseconds since page-load or 0 if unsupported
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+    let r = Math.random() * 16; //random number between 0 and 16
+    if (d > 0) {
+      //Use timestamp until depleted
+      r = (d + r) % 16 | 0;
+      d = Math.floor(d / 16);
+    } else {
+      //Use microseconds since page-load if supported
+      r = (d2 + r) % 16 | 0;
+      d2 = Math.floor(d2 / 16);
+    }
+    return (c === "x" ? r : (r & 0x3) | 0x8).toString(16);
+  });
+}
+
 export default class YPartyKitProvider extends WebsocketProvider {
   constructor(
     host: string,
@@ -15,10 +41,10 @@ export default class YPartyKitProvider extends WebsocketProvider {
     }://${host}/party`;
     if (options.params === undefined) {
       options.params = {
-        _pk: crypto.randomUUID(),
+        _pk: generateUUID(),
       };
     } else {
-      options.params._pk = crypto.randomUUID();
+      options.params._pk = generateUUID();
     }
     super(serverUrl, room, doc, options);
   }


### PR DESCRIPTION
This uses a weaker implementation to generate conneciton IDs if crypto.randomUUID() isn't available in the browser (re: https://github.com/WICG/uuid/issues/23) Fixes https://github.com/partykit/partykit/issues/53