### PR TITLE
feat: onRequest/onBeforeRequest

### DIFF
--- a/.changeset/dry-cars-accept.md
+++ b/.changeset/dry-cars-accept.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+feat: onRequest/onBeforeRequest
+
+This feature allows you to optionally configure onBeforeRequest/onRequest on a room. just like oBC/oC, the former runs in a worker closest to you, and the later runs in the room. This also makes defining onConnect fully optional. This should open the door to some interesting integrations.

--- a/examples/basic/src/server.ts
+++ b/examples/basic/src/server.ts
@@ -14,4 +14,16 @@ export default {
   async onBeforeConnect(_req: Request) {
     return { x: 1 };
   },
+  async onBeforeRequest(req: Request) {
+    return new Request(req.url, {
+      headers: {
+        "x-foo": "bar",
+      },
+    });
+  },
+  async onRequest(req: Request, room) {
+    return new Response(
+      "Hello world:" + req.headers.get("x-foo") + " " + room.id
+    );
+  },
 } satisfies PartyKitServer;

--- a/packages/partykit/src/cli.ts
+++ b/packages/partykit/src/cli.ts
@@ -366,7 +366,7 @@ export async function dev(
   const proxy = httpProxy.default.createProxyServer();
 
   // TODO: maybe we can just use urlpattern here
-  app.get("/party/:roomId", async (req, res) => {
+  app.all("/party/:roomId", async (req, res) => {
     const room = await getRoom(req.params.roomId);
 
     proxy.web(req, res, {

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -35,6 +35,12 @@ export type PartyKitRoom = {
 };
 
 export type PartyKitServer<Initial = unknown> = {
-  onConnect: (ws: WebSocket, room: PartyKitRoom) => void | Promise<void>;
+  onConnect?: (ws: WebSocket, room: PartyKitRoom) => void | Promise<void>;
   onBeforeConnect?: (req: Request) => Initial | Promise<Initial>;
+
+  onBeforeRequest?: (req: Request) => Request | Promise<Request>;
+  onRequest?: (
+    req: Request,
+    room: PartyKitRoom
+  ) => Response | Promise<Response>;
 };


### PR DESCRIPTION
This feature allows you to optionally configure onBeforeRequest/onRequest on a room. just like oBC/oC, the former runs in a worker closest to you, and the later runs in the room. This also makes defining onConnect fully optional.  This should open the door to some interesting integrations.