### PR TITLE
remove y-partykit's onCommand config

### DIFF
--- a/.changeset/healthy-terms-argue.md
+++ b/.changeset/healthy-terms-argue.md
@@ -1,0 +1,7 @@
+---
+"y-partykit": patch
+---
+
+remove y-partykit's onCommand config
+
+now that we have onRequest, we don't need to set up a command channel within y-partykit itself, so let's remove the code for it.

--- a/examples/monaco/src/server.ts
+++ b/examples/monaco/src/server.ts
@@ -4,17 +4,6 @@ export default {
   onConnect(ws, room) {
     onConnect(ws, room, {
       persist: true,
-      onCommand(command, _doc) {
-        switch (command) {
-          case "do-the-thing": {
-            console.log("we did the thing");
-            break;
-          }
-          default: {
-            console.warn("unrecognised message");
-          }
-        }
-      },
     });
   },
 } satisfies PartyKitServer;

--- a/packages/y-partykit/src/index.ts
+++ b/packages/y-partykit/src/index.ts
@@ -311,7 +311,6 @@ export type YPartyKitOptions = {
    * disable gc when using snapshots!
    * */
   gc?: boolean;
-  onCommand?: (command: string, doc: WSSharedDoc) => void | Promise<void>;
   persist?: boolean;
   callback?: {
     url: string;
@@ -336,10 +335,8 @@ export function onConnect(
   conn.addEventListener("message", async (message) => {
     if (typeof message.data !== "string") {
       return messageListener(conn, doc, new Uint8Array(message.data));
-    } else if (options.onCommand) {
-      await options.onCommand(message.data, doc);
     } else {
-      console.warn("unhandled message", message.data);
+      // silently ignore anything else
     }
   });
 


### PR DESCRIPTION
now that we have onRequest, we don't need to set up a command channel within y-partykit itself, so let's remove the code for it.