### PR TITLE
Add callback.handler to y-partykit for programmatic callback

### DIFF
--- a/packages/y-partykit/src/index.ts
+++ b/packages/y-partykit/src/index.ts
@@ -73,8 +73,9 @@ class WSSharedDoc extends Y.Doc {
     ) => {
       const changedClients = added.concat(updated, removed);
       if (conn !== null) {
-        const connControlledIDs =
-          /** @type {Set<number>} */ this.conns.get(conn);
+        const connControlledIDs = /** @type {Set<number>} */ this.conns.get(
+          conn
+        );
         if (connControlledIDs !== undefined) {
           added.forEach((clientID) => {
             connControlledIDs.add(clientID);
@@ -320,6 +321,7 @@ interface CallbackOptions {
 }
 
 // Either handler or url needs to be defined, but not both
+// TODO: Add a runtime check for this
 
 interface HandlerCallbackOptions extends CallbackOptions {
   handler: (doc: Y.Doc) => void;


### PR DESCRIPTION
This PR adds a new `handler` property to the y-partykit callback configuration.

This allows the consumer more granular control over how to serialize the document, and what to do with it. See for example:

```ts
    onConnect(ws, room, {
      callback: {
        handler(doc) {
          const html = transformer.fromYdoc(doc);
          sendToPrimaryStorage(html)
        },
        debounceWait: 2000,
        debounceMaxWait: 30000,
      },
    });
```

This PR tries to make the minimal change and does not change the existing `url` option, so you can still provide both `url` and `handler` options.

This may not be the best API going forward, but I didn't want to propose a breaking change.