### PR TITLE
Add room parameter to onBeforeConnect

### DIFF
--- a/.changeset/real-mangos-cheat.md
+++ b/.changeset/real-mangos-cheat.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Add room-like parameter to onBeforeConnect/onBeforeRequest

--- a/package-lock.json
+++ b/package-lock.json
@@ -316,6 +316,7 @@
       }
     },
     "examples/yjs": {
+      "name": "@partykit/examples-yjs",
       "version": "0.0.0",
       "license": "ISC"
     },

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -34,7 +34,10 @@ async function handleRequest(request: Request): Promise<Response> {
       if (Worker.onBeforeConnect) {
         let initialRes: unknown;
         try {
-          initialRes = await Worker.onBeforeConnect(request, partyRoom);
+          initialRes = await Worker.onBeforeConnect(request, {
+            id: partyRoom.id,
+            env: partyRoom.env,
+          });
         } catch (e) {
           return new Response(
             (e as Error).message || `${e}` || "Unauthorized",
@@ -54,7 +57,10 @@ async function handleRequest(request: Request): Promise<Response> {
     } else {
       let req: Request = request;
       if (Worker.onBeforeRequest) {
-        req = await Worker.onBeforeRequest(request);
+        req = await Worker.onBeforeRequest(request, {
+          id: partyRoom.id,
+          env: partyRoom.env,
+        });
       }
       if (Worker.onRequest) {
         return Worker.onRequest(req, partyRoom);

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -38,10 +38,13 @@ export type PartyKitServer<Initial = unknown> = {
   onConnect?: (ws: WebSocket, room: PartyKitRoom) => void | Promise<void>;
   onBeforeConnect?: (
     req: Request,
-    room: PartyKitRoom
+    room: { id: string; env: Record<string, string> }
   ) => Initial | Promise<Initial>;
 
-  onBeforeRequest?: (req: Request) => Request | Promise<Request>;
+  onBeforeRequest?: (
+    req: Request,
+    room: { id: string; env: Record<string, string> }
+  ) => Request | Promise<Request>;
   onRequest?: (
     req: Request,
     room: PartyKitRoom


### PR DESCRIPTION
In onBeforeConnect, we'd like to access the room so we can have access to `room.id` and `room.env`. 

Example:
```ts
  async onBeforeConnect(req, room) {
    const token = new URL(req.url).searchParams.get('token');
    const apiUrl = room.env.GRAPHQL_API_URL;
    return authenticate(apiUrl, room.id, token);
  }
```

I wasn't sure if the room was omitted from the onBeforeConnect callback on purpose, but this seems like the cleanest way to do this. 

If this is not how it's supposed to work, suggestions for a better approach welcome!

