### PR TITLE
Make partysocket compatible with both esm and cjs

### DIFF
--- a/.changeset/strong-singers-sleep.md
+++ b/.changeset/strong-singers-sleep.md
@@ -1,0 +1,5 @@
+---
+"partysocket": patch
+---
+
+Makes partysocket compatible with both esm and cjs.

--- a/packages/partysocket/package.json
+++ b/packages/partysocket/package.json
@@ -2,16 +2,28 @@
   "name": "partysocket",
   "version": "0.0.1",
   "description": "party hotline",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "exports": {
-    ".": "./dist/index.js",
-    "./ws": "./dist/ws.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./ws": {
+      "import": "./dist/esm/ws.js",
+      "require": "./dist/cjs/ws.js"
+    },
+    "./react": {
+      "import": "./dist/esm/react.js",
+      "require": "./dist/cjs/react.js"
+    }
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf dist && rm -rf *.d.ts*",
-    "build": "npm run clean && npx esbuild src/index.ts src/react.ts src/ws.ts --format=cjs --outdir=dist && tsc --project tsconfig.extract.json && mv dist/*.d.ts* ."
+    "build:cjs": "npx esbuild src/index.ts src/react.ts src/ws.ts --format=cjs --outdir=dist/cjs",
+    "build:esm": "npx esbuild src/index.ts src/react.ts src/ws.ts --format=esm --outdir=dist/esm",
+    "build": "npm run clean && npm run build:cjs && npm run build:esm && tsc --project tsconfig.extract.json && mv dist/*.d.ts* ."
   },
   "files": [
     "dist/*.js",


### PR DESCRIPTION
I've now got myself in a situation where I need both `esm` and `cjs` compatibility 😅 So I've tried to update package.json to reflect that.