### PR TITLE
Fix included files in published build

### DIFF
--- a/.changeset/lucky-deers-bow.md
+++ b/.changeset/lucky-deers-bow.md
@@ -1,0 +1,5 @@
+---
+"partysocket": patch
+---
+
+Fix included files in published build.

--- a/packages/partysocket/package.json
+++ b/packages/partysocket/package.json
@@ -26,7 +26,7 @@
     "build": "npm run clean && npm run build:cjs && npm run build:esm && tsc --project tsconfig.extract.json && mv dist/*.d.ts* ."
   },
   "files": [
-    "dist/*.js",
+    "dist/**/*.js",
     "*.d.ts",
     "*.d.ts.map"
   ],


### PR DESCRIPTION
The previously published build of `partysocket` didn't work because the glob pattern in the files array was not updated to match the two new subfolders.