### PR TITLE
deploy --with-vars, and fixes for env commands

### DIFF
--- a/.changeset/smooth-coats-flash.md
+++ b/.changeset/smooth-coats-flash.md
@@ -1,0 +1,9 @@
+---
+"partykit": patch
+---
+
+deploy --with-vars, and fixes for env commands
+
+- running `deploy --with-vars` now reads values from config files
+- `env pull` now writes to `partykit.json`
+- env commands don't fail if a `main` isn't specified

--- a/packages/partykit/src/bin.ts
+++ b/packages/partykit/src/bin.ts
@@ -2,7 +2,7 @@
 import * as cli from "./cli";
 import { fetchUserConfig, logout } from "./config";
 import { version } from "../package.json";
-import { program, Option } from "commander";
+import { program /*, Option*/ } from "commander";
 
 import packageJson from "../package.json";
 
@@ -50,10 +50,10 @@ function getArrayKVOption(val: string[] = []) {
   }, {} as Record<string, string>);
 }
 
-const EnvironmentOption = new Option(
-  "-e, --env <env>",
-  "environment to use"
-).choices(["production", "development", "preview"]);
+// const EnvironmentOption = new Option(
+//   "-e, --env <env>",
+//   "environment to use"
+// ).choices(["production", "development", "preview"]);
 
 program
   .name("partykit")
@@ -103,9 +103,13 @@ program
     "-d, --define [defines...]",
     "A key-value pair to be substituted in the script"
   )
+  .option("--with-vars", "include all variables in the deployment")
   .option("-n, --name <name>", "name of the project")
   .option("--preview [name]", "deploy to preview environment")
   .action(async (scriptPath, options) => {
+    if (options.withVars) {
+      console.warn("--with-vars is not yet implemented");
+    }
     await cli.deploy({
       main: scriptPath,
       name: options.name,
@@ -113,6 +117,7 @@ program
       vars: getArrayKVOption(options.var),
       define: getArrayKVOption(options.define),
       preview: options.preview,
+      withVars: options.withVars,
     });
   });
 
@@ -140,7 +145,7 @@ envCommand
   .description("list all environment variables")
   .option("-n, --name <name>", "name of the project")
   .option("-c, --config <path>", "path to config file")
-  .addOption(EnvironmentOption)
+  // .addOption(EnvironmentOption)
   // -p preview id?
   .action(async (options) => {
     await cli.env.list(options);
@@ -154,7 +159,7 @@ envCommand
   .option("-c, --config <path>", "path to config file")
   .option("--preview [name]", "pull from preview")
   .action(async (fileName, options) => {
-    await cli.env.pull(fileName || ".env", options);
+    await cli.env.pull(fileName, options);
   });
 
 envCommand
@@ -174,7 +179,7 @@ envCommand
   .option("-n, --name <name>", "name of the project")
   .option("-c, --config <path>", "path to config file")
   .option("--preview [name]", "add to preview")
-  .addOption(EnvironmentOption)
+  // .addOption(EnvironmentOption)
   // -p preview id?
   .action(async (key, options) => {
     await cli.env.add(key, options);
@@ -187,7 +192,7 @@ envCommand
   .option("-n, --name <name>", "name of the project")
   .option("-c, --config <path>", "path to config file")
   .option("--preview [name]", "remove from preview")
-  .addOption(EnvironmentOption)
+  // .addOption(EnvironmentOption)
   .action(async (key, options) => {
     await cli.env.remove(key, options);
   });

--- a/packages/partykit/src/tests/config.test.ts
+++ b/packages/partykit/src/tests/config.test.ts
@@ -22,11 +22,10 @@ afterEach(() => {
 
 describe("config", () => {
   it("should return a default config", () => {
-    const config = getConfig(undefined, { main: "script.js" });
+    const config = getConfig(undefined, undefined);
     expect(config).toMatchInlineSnapshot(`
       {
         "define": {},
-        "main": "./script.js",
         "vars": {},
       }
     `);
@@ -34,7 +33,6 @@ describe("config", () => {
 
   it("should return a config with overrides", () => {
     const config = getConfig(undefined, {
-      main: "script.js",
       vars: {
         test: "test",
       },
@@ -42,7 +40,6 @@ describe("config", () => {
     expect(config).toMatchInlineSnapshot(`
       {
         "define": {},
-        "main": "./script.js",
         "vars": {
           "test": "test",
         },
@@ -52,11 +49,10 @@ describe("config", () => {
 
   it("should read values from a .env file", () => {
     fs.writeFileSync(".env", "test=test");
-    const config = getConfig(undefined, { main: "script.js" });
+    const config = getConfig(undefined, undefined);
     expect(config).toMatchInlineSnapshot(`
       {
         "define": {},
-        "main": "./script.js",
         "vars": {
           "test": "test",
         },
@@ -67,7 +63,6 @@ describe("config", () => {
   it("should read values from a .env file and override with overrides", () => {
     fs.writeFileSync(".env", "test=test");
     const config = getConfig(undefined, {
-      main: "script.js",
       vars: {
         test: "test2",
       },
@@ -75,7 +70,6 @@ describe("config", () => {
     expect(config).toMatchInlineSnapshot(`
       {
         "define": {},
-        "main": "./script.js",
         "vars": {
           "test": "test2",
         },
@@ -89,7 +83,6 @@ describe("config", () => {
     const config = getConfig(
       undefined,
       {
-        main: "script.js",
         vars: {
           test4: "test4",
         },
@@ -99,7 +92,6 @@ describe("config", () => {
     expect(config).toMatchInlineSnapshot(`
       {
         "define": {},
-        "main": "./script.js",
         "vars": {
           "test": "test3",
           "test2": "test2",
@@ -113,7 +105,6 @@ describe("config", () => {
     fs.writeFileSync(
       "partykit.json",
       JSON.stringify({
-        main: "script.js",
         vars: {
           test: "test",
         },
@@ -123,7 +114,6 @@ describe("config", () => {
     expect(config).toMatchInlineSnapshot(`
       {
         "define": {},
-        "main": "./script.js",
         "vars": {
           "test": "test",
         },
@@ -393,15 +383,6 @@ describe("config", () => {
               }
             ]"
           `);
-    });
-
-    it("should error when main is not provided", () => {
-      fs.writeFileSync("partykit.json", JSON.stringify({}));
-      expect(() =>
-        getConfig(undefined, undefined)
-      ).toThrowErrorMatchingInlineSnapshot(
-        '"Missing entry point, please specify \\"main\\" in your config"'
-      );
     });
 
     it("should error on a path that doesn't exist", () => {

--- a/packages/partykit/src/tests/dev.test.ts
+++ b/packages/partykit/src/tests/dev.test.ts
@@ -22,7 +22,9 @@ afterEach(async () => {
 
 describe("dev", () => {
   it("should error if no script path is provided", async () => {
-    await expect(runDev({})).rejects.toThrowErrorMatchingInlineSnapshot('"Missing entry point, please specify \\"main\\" in your config"');
+    await expect(runDev({})).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"Missing entry point, please specify \\"main\\" in your config"'
+    );
   });
 
   it("should start a server for a given input script path", async () => {

--- a/packages/partykit/src/tests/env.test.ts
+++ b/packages/partykit/src/tests/env.test.ts
@@ -1,0 +1,240 @@
+import fs from "fs";
+import { env } from "../cli";
+import { vi, beforeEach, expect, describe, test, afterEach } from "vitest";
+import { mockConsoleMethods } from "./mock-console";
+import { mockFetchResult, clearMocks } from "./fetchResult-mock";
+
+vi.mock("../fetchResult", async () => {
+  const { fetchResult } = await import("./fetchResult-mock");
+  return {
+    fetchResult,
+  };
+});
+
+process.env.GITHUB_LOGIN = "test-user";
+process.env.GITHUB_TOKEN = "test-token";
+
+const std = mockConsoleMethods();
+
+const currDir = process.cwd();
+
+beforeEach(() => {
+  clearMocks();
+  // create a tmp dir
+  const dirPath = fs.mkdtempSync("pk-test-env");
+  // set the cwd to the tmp dir
+  process.chdir(dirPath);
+});
+
+afterEach(() => {
+  // switch back to the original dir
+  const tmpDir = process.cwd();
+  process.chdir(currDir);
+  // remove the tmp dir
+  fs.rmdirSync(tmpDir, { recursive: true });
+});
+
+describe("env", () => {
+  test("list", async () => {
+    let checkedResponse = false;
+    mockFetchResult(
+      "GET",
+      `/parties/test-user/my-project/env?keys=true`,
+      (_url, _options) => {
+        checkedResponse = true;
+        return ["a", "b", "c", "d"];
+      }
+    );
+
+    await env.list({
+      name: "my-project",
+      config: undefined,
+      preview: undefined,
+    });
+    expect(checkedResponse).toBe(true);
+    expect(std).toMatchInlineSnapshot(`
+        {
+          "debug": "",
+          "err": "",
+          "info": "",
+          "out": "[ 'a', 'b', 'c', 'd' ]",
+          "warn": "",
+        }
+      `);
+  });
+
+  test("pull", async () => {
+    let checkedResponse = false;
+    mockFetchResult(
+      "GET",
+      `/parties/test-user/my-project/env`,
+      (_url, _options) => {
+        checkedResponse = true;
+        return {
+          a: "a1",
+          b: "b2",
+          c: "c3",
+          d: "d4",
+        };
+      }
+    );
+
+    await env.pull(undefined, {
+      name: "my-project",
+      config: undefined,
+      preview: undefined,
+    });
+
+    expect(checkedResponse).toBe(true);
+    expect(std).toMatchInlineSnapshot(`
+      {
+        "debug": "",
+        "err": "",
+        "info": "",
+        "out": "Creating partykit.json...",
+        "warn": "",
+      }
+    `);
+    expect(fs.existsSync("partykit.json")).toBe(true);
+    expect(fs.readFileSync("partykit.json", "utf-8")).toMatchInlineSnapshot(`
+      "{
+        \\"name\\": \\"my-project\\",
+        \\"vars\\": {
+          \\"a\\": \\"a1\\",
+          \\"b\\": \\"b2\\",
+          \\"c\\": \\"c3\\",
+          \\"d\\": \\"d4\\"
+        }
+      }
+      "
+    `);
+  });
+
+  describe("push", () => {
+    test("push with no config", async () => {
+      await env.push({
+        name: "my-project",
+        config: undefined,
+        preview: undefined,
+      });
+
+      expect(std).toMatchInlineSnapshot(`
+        {
+          "debug": "",
+          "err": "",
+          "info": "",
+          "out": "",
+          "warn": "No environment variables to push, exiting...",
+        }
+      `);
+    });
+
+    test("push with config", async () => {
+      fs.writeFileSync(
+        "partykit.json",
+        JSON.stringify({
+          name: "my-project",
+          vars: {
+            a: "a1",
+            b: "b2",
+            c: "c3",
+            d: "d4",
+          },
+        })
+      );
+
+      let checkedResponse = false;
+      mockFetchResult(
+        "POST",
+        `/parties/test-user/my-project/env`,
+        (_url, options) => {
+          expect(JSON.parse(options?.body as string)).toMatchInlineSnapshot(`
+            {
+              "a": "a1",
+              "b": "b2",
+              "c": "c3",
+              "d": "d4",
+            }
+          `);
+          checkedResponse = true;
+          return {
+            success: true,
+          };
+        }
+      );
+
+      await env.push({
+        name: "my-project",
+        config: undefined,
+        preview: undefined,
+      });
+
+      expect(checkedResponse).toBe(true);
+      expect(std).toMatchInlineSnapshot(`
+        {
+          "debug": "",
+          "err": "",
+          "info": "",
+          "out": "Loading config from partykit.json
+        Pushed environment variables",
+          "warn": "",
+        }
+      `);
+    });
+  });
+
+  // skipping this one so we can figure out how to mock prompts
+  test.skip("add", async () => {
+    let checkedResponse = false;
+    mockFetchResult(
+      "POST",
+      `/parties/test-user/my-project/env`,
+      (_url, _options) => {
+        checkedResponse = true;
+        return {
+          success: true,
+        };
+      }
+    );
+
+    await env.add("key", {
+      name: "my-project",
+      config: undefined,
+      preview: undefined,
+    });
+
+    expect(checkedResponse).toBe(true);
+    expect(std).toMatchInlineSnapshot();
+  });
+
+  test("remove", async () => {
+    let checkedResponse = false;
+    mockFetchResult(
+      "DELETE",
+      `/parties/test-user/my-project/env/some-key`,
+      (_url, _options) => {
+        checkedResponse = true;
+        return {
+          success: true,
+        };
+      }
+    );
+
+    await env.remove("some-key", {
+      name: "my-project",
+      config: undefined,
+      preview: undefined,
+    });
+
+    expect(checkedResponse).toBe(true);
+    expect(std).toMatchInlineSnapshot(`
+      {
+        "debug": "",
+        "err": "",
+        "info": "",
+        "out": "{ success: true }",
+        "warn": "",
+      }
+    `);
+  });
+});

--- a/packages/partykit/src/tests/fetchResult-mock.ts
+++ b/packages/partykit/src/tests/fetchResult-mock.ts
@@ -23,10 +23,10 @@ export async function fetchResult<T>(
   options: RequestInit = {}
 ): Promise<T> {
   const mock = mocks.find(([method, mockUrl]) => {
-    return mockUrl === url && method === options.method;
+    return mockUrl === url && method === (options.method || "GET");
   });
   if (mock) {
     return mock[2](url, options) as T;
   }
-  throw new Error(`No mock for ${url} ${options.method}`);
+  throw new Error(`No mock for ${url} ${options.method || "GET"}`);
 }

--- a/packages/partykit/src/tests/mock-console.ts
+++ b/packages/partykit/src/tests/mock-console.ts
@@ -1,0 +1,111 @@
+import * as util from "node:util";
+import { beforeEach, afterEach, vi } from "vitest";
+import type { SpyInstance } from "vitest";
+/**
+ * We use this module to mock console methods, and optionally
+ * assert on the values they're called with in our tests.
+ */
+
+let debugSpy: SpyInstance,
+  logSpy: SpyInstance,
+  infoSpy: SpyInstance,
+  errorSpy: SpyInstance,
+  warnSpy: SpyInstance;
+
+const std = {
+  get debug() {
+    return normalizeOutput(debugSpy);
+  },
+  get out() {
+    return normalizeOutput(logSpy);
+  },
+  get info() {
+    return normalizeOutput(infoSpy);
+  },
+  get err() {
+    return normalizeOutput(errorSpy);
+  },
+  get warn() {
+    return normalizeOutput(warnSpy);
+  },
+};
+
+function normalizeOutput(spy: SpyInstance): string {
+  return normalizeErrorMarkers(
+    replaceByte(
+      stripTrailingWhitespace(
+        normalizeSlashes(normalizeTempDirs(stripTimings(captureCalls(spy))))
+      )
+    )
+  );
+}
+
+function captureCalls(spy: SpyInstance): string {
+  return spy.mock.calls
+    .map((args: unknown[]) => util.format("%s", ...args))
+    .join("\n");
+}
+
+export function mockConsoleMethods() {
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, "debug");
+    logSpy = vi.spyOn(console, "log");
+    infoSpy = vi.spyOn(console, "info");
+    errorSpy = vi.spyOn(console, "error");
+    warnSpy = vi.spyOn(console, "warn");
+  });
+  afterEach(() => {
+    debugSpy.mockRestore();
+    logSpy.mockRestore();
+    infoSpy.mockRestore();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+  return std;
+}
+
+/**
+ * Normalize error `X` markers.
+ *
+ * Windows gets a different character.
+ */
+function normalizeErrorMarkers(str: string): string {
+  return str.replaceAll("✘", "X");
+}
+
+/**
+ * Ensure slashes in the `str` are OS file-system agnostic.
+ *
+ * Use this in snapshot tests to be resilient to file-system differences.
+ */
+export function normalizeSlashes(str: string): string {
+  return str.replace(/\\/g, "/");
+}
+
+/**
+ * Strip "timing data" out of the `stdout` string, since this is not always deterministic.
+ *
+ * Use this in snapshot tests to be resilient to slight changes in timing of processing.
+ */
+export function stripTimings(stdout: string): string {
+  return stdout.replace(/\(\d+\.\d+ sec\)/g, "(TIMINGS)");
+}
+
+export function stripTrailingWhitespace(str: string): string {
+  return str.replace(/[^\S\n]+\n/g, "\n");
+}
+
+/**
+ * Removing leading kilobit (tenth of a byte) from test output due to
+ * variation causing every few tests the value to change by ± .01
+ */
+function replaceByte(stdout: string): string {
+  return stdout.replaceAll(/\d+\.\d+ KiB/g, "xx KiB");
+}
+
+/**
+ * Temp directories are created with random names, so we replace all comments temp dirs in them
+ */
+export function normalizeTempDirs(stdout: string): string {
+  return stdout.replaceAll(/\/\/.+\/tmp.+/g, "//tmpdir");
+}


### PR DESCRIPTION
- running `deploy --with-vars` now reads values from config files
- `env pull` now writes to `partykit.json`
- env commands don't fail if a `main` isn't specified