### PR TITLE
Ensure that commander expects port to be a number

### DIFF
--- a/.changeset/giant-cows-grow.md
+++ b/.changeset/giant-cows-grow.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Ensure that commander expects port to be a number.

--- a/packages/partykit/src/bin.ts
+++ b/packages/partykit/src/bin.ts
@@ -64,7 +64,7 @@ program
   .command("dev")
   .description("run a script in development mode")
   .argument("[script]", "path to the script to run")
-  .option("-p, --port", "port to run the server on")
+  .option("-p, --port <number>", "port to run the server on")
   // .option("--assets", "path to assets directory")
   .option("-c, --config <path>", "path to config file")
   // .option("-e, --env", "environment to use")


### PR DESCRIPTION
This PR changes the port option config to be a number.