### PR TITLE
feat: `tail` for live logs

### DIFF
--- a/.changeset/early-coats-judge.md
+++ b/.changeset/early-coats-judge.md
@@ -1,0 +1,12 @@
+---
+"partykit": patch
+---
+
+feat: `tail` for live logs
+
+running `partykit tail --name <project>` will now hook into a project's production logs and stream them live. This is a full clone of `wrangler tail`. Two notes:
+
+- there's a bug with cf where logs on websocket connections don't come through until the websocket disconnects
+- the filter aren't tested yet
+
+That said, this is a good start, so let's land it and see what to fix after.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2375,6 +2375,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/signal-exit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/signal-exit/-/signal-exit-3.0.1.tgz",
+      "integrity": "sha512-OSitN9PP9E/c4tlt1Qdj3CAz5uHD9Da5rhUqlaKyQRCX1T7Zdpbk6YdeZbR2eiE2ce+NMBgVnMxGqpaPSNQDUQ==",
+      "dev": true
+    },
     "node_modules/@types/stack-trace": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
@@ -8607,7 +8613,8 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -10444,6 +10451,7 @@
         "@types/http-proxy": "^1.17.10",
         "@types/node": "^18.15.3",
         "@types/prompts": "^2.4.3",
+        "@types/signal-exit": "^3.0.1",
         "@types/update-notifier": "^6.0.2",
         "@types/ws": "^8.5.4",
         "chalk": "^5.2.0",
@@ -10456,6 +10464,7 @@
         "json5": "^2.2.3",
         "open": "^8.4.2",
         "prompts": "^2.4.2",
+        "signal-exit": "^3.0.7",
         "ws": "^8.13.0",
         "zod": "^3.21.4"
       }

--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -20,6 +20,7 @@
     "@types/http-proxy": "^1.17.10",
     "@types/node": "^18.15.3",
     "@types/prompts": "^2.4.3",
+    "@types/signal-exit": "^3.0.1",
     "@types/update-notifier": "^6.0.2",
     "@types/ws": "^8.5.4",
     "chalk": "^5.2.0",
@@ -32,6 +33,7 @@
     "json5": "^2.2.3",
     "open": "^8.4.2",
     "prompts": "^2.4.2",
+    "signal-exit": "^3.0.7",
     "ws": "^8.13.0",
     "zod": "^3.21.4"
   },

--- a/packages/partykit/src/bin.ts
+++ b/packages/partykit/src/bin.ts
@@ -2,7 +2,7 @@
 import * as cli from "./cli";
 import { fetchUserConfig, logout } from "./config";
 import { version } from "../package.json";
-import { program /*, Option*/ } from "commander";
+import { Option, program /*, Option*/ } from "commander";
 
 import packageJson from "../package.json";
 
@@ -136,6 +136,37 @@ program
   .option("--preview [name]", "delete preview")
   .action(async (options) => {
     await cli._delete(options);
+  });
+
+program
+  .command("tail")
+  .description("tail logs from a deployed project")
+  .option("-n, --name <name>", "name of the project")
+  .option("-c, --config <path>", "path to config file")
+  .option("--preview [name]", "tail logs from preview")
+  .addOption(
+    new Option("-f, --format", "format of the logs")
+      .choices(["json", "pretty"])
+      .default("pretty")
+  )
+  .option("--debug", "show debug logs", false)
+  .addOption(
+    new Option("--status", "filter by invocation status").choices([
+      "ok",
+      "error",
+      "canceled",
+    ])
+  )
+  .option("--header", "filter by HTTP header")
+  .option("--method <...methods>", "filter by HTTP method(s)")
+  .option("--sampling-rate <number>", "sampling rate of logs")
+  .option("--search <string>", "search for a string in the logs")
+  .option(
+    "--ip <..ips>",
+    'filter by the IP address the request originates from (use "self" to filter for your own IP)'
+  )
+  .action(async (options) => {
+    await cli.tail(options);
   });
 
 const envCommand = program.command("env");

--- a/packages/partykit/src/tail/filters.ts
+++ b/packages/partykit/src/tail/filters.ts
@@ -1,0 +1,277 @@
+/**
+ * When tailing logs from a worker, oftentimes you don't want to see _every
+ * single event_. That's where filters come in. We can send a set of filters
+ * to the tail worker, and it will pre-filter any logs for us so that we
+ * only recieve the ones we care about.
+ */
+
+/**
+ * These are the filters we accept in the CLI. They
+ * were copied directly from Wrangler v1 in order to
+ * maintain compatability, so they aren't actually the exact
+ * filters we need to send up to the tail worker. They generally map 1:1,
+ * but often require some transformation or
+ * renaming to match what it expects.
+ *
+ * For a full description of each filter, either check the
+ * CLI description or see the documentation for `ApiFilter`.
+ */
+export type TailCLIFilters = {
+  status?: ("ok" | "error" | "canceled")[];
+  header?: string;
+  method?: string[];
+  search?: string;
+  samplingRate?: number;
+  clientIp?: string[];
+};
+
+/**
+ * These are the filters we send to the tail worker. We
+ * actually send a list of filters (an array of objects),
+ * so rather than having a single TailAPIFilters type,
+ * each kind of filter gets its own type and we define
+ * TailAPIFilter to be the union of those types.
+ */
+export type TailAPIFilter =
+  | SamplingRateFilter
+  | OutcomeFilter
+  | MethodFilter
+  | HeaderFilter
+  | ClientIPFilter
+  | QueryFilter;
+
+/**
+ * Filters logs based on a given sampling rate.
+ * For example, a `sampling_rate` of 0.25 will let one-quarter of the
+ * logs through.
+ */
+type SamplingRateFilter = {
+  sampling_rate: number;
+};
+
+/**
+ * Filters logs based on the outcome of the worker's event handler.
+ */
+type OutcomeFilter = {
+  outcome: Outcome[];
+};
+
+/**
+ * There are five possible outcomes we can get, three of which
+ * (exception, exceededCpu, exceededMemory, and unknown) are considered errors
+ */
+export type Outcome =
+  | "ok"
+  | "canceled"
+  | "exception"
+  | "exceededCpu"
+  | "exceededMemory"
+  | "unknown";
+
+/**
+ * Filters logs based on the HTTP method used for the request
+ * that triggered the worker.
+ */
+type MethodFilter = {
+  method: string[];
+};
+
+/**
+ * Filters logs based on an HTTP header on the request that
+ * triggered the worker.
+ */
+type HeaderFilter = {
+  header: {
+    /**
+     * Filters on the header "key", e.g. "X-CLOUDFLARE-HEADER"
+     * or "X-CUSTOM-HEADER"
+     */
+    key: string;
+
+    /**
+     * Filters on the header "value", e.g. if this is set to
+     * "filter-for-me" and the "key" is "X-SHOULD-LOG", only
+     * events triggered by requests with the header
+     * "X-SHOULD-LOG:filter-for-me" will be logged.
+     */
+    query?: string;
+  };
+};
+
+/**
+ * Filters on the IP address the request came from that triggered
+ * the worker. A value of "self" will be replaced with the IP
+ * address that is running `wrangler tail`
+ */
+type ClientIPFilter = {
+  client_ip: string[];
+};
+
+/**
+ * Filters logs by a query string. This means only logs that
+ * contain the given string will be sent to wrangler, and any
+ * that don't will be discarded by the tail worker.
+ */
+type QueryFilter = {
+  query: string;
+};
+
+/**
+ * The full message we send to the tail worker includes our
+ * filters and a debug flag.
+ */
+export type TailFilterMessage = {
+  filters: TailAPIFilter[];
+};
+
+/**
+ * Translate the flags passed in via a CLI invokation of wrangler
+ * into a message that we can send to the tail worker.
+ *
+ * @param cliFilters An object containing all the filters passed in from the CLI
+ * @returns A filter message ready to be sent to the tail worker
+ */
+export function translateCLICommandToFilterMessage(
+  cliFilters: TailCLIFilters
+): TailFilterMessage {
+  const apiFilters: TailAPIFilter[] = [];
+
+  if (cliFilters.samplingRate) {
+    apiFilters.push(parseSamplingRate(cliFilters.samplingRate));
+  }
+
+  if (cliFilters.status) {
+    apiFilters.push(parseOutcome(cliFilters.status));
+  }
+
+  if (cliFilters.method) {
+    apiFilters.push(parseMethod(cliFilters.method));
+  }
+
+  if (cliFilters.header) {
+    apiFilters.push(parseHeader(cliFilters.header));
+  }
+
+  if (cliFilters.clientIp) {
+    apiFilters.push(parseIP(cliFilters.clientIp));
+  }
+
+  if (cliFilters.search) {
+    apiFilters.push(parseQuery(cliFilters.search));
+  }
+
+  return {
+    filters: apiFilters,
+  };
+}
+
+/**
+ * Parse the sampling rate passed in via command line
+ *
+ * @param sampling_rate the sampling rate passed in via CLI
+ * @throws an Error if the rate doesn't make sense
+ * @returns a SamplingRateFilter for use with the API
+ */
+function parseSamplingRate(sampling_rate: number): SamplingRateFilter {
+  if (sampling_rate <= 0 || sampling_rate >= 1) {
+    throw new Error(
+      "A sampling rate must be between 0 and 1 in order to have any effect.\nFor example, a sampling rate of 0.25 means 25% of events will be logged."
+    );
+  }
+
+  return { sampling_rate };
+}
+
+/**
+ * Translate from CLI "status"es to API "outcome"s, including
+ * broadening "error" into "exception", "exceededCpu", and "unknown".
+ *
+ * @param statuses statuses passed in via CLI
+ * @returns an OutcomeFilter for use with the API
+ */
+function parseOutcome(
+  statuses: ("ok" | "error" | "canceled")[]
+): OutcomeFilter {
+  const outcomes = new Set<Outcome>();
+
+  for (const status of statuses) {
+    switch (status) {
+      case "ok":
+        outcomes.add("ok");
+        break;
+
+      case "canceled":
+        outcomes.add("canceled");
+        break;
+
+      case "error":
+        outcomes.add("exception");
+        outcomes.add("exceededCpu");
+        outcomes.add("exceededMemory");
+        outcomes.add("unknown");
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  return {
+    outcome: Array.from(outcomes),
+  };
+}
+
+/**
+ * We just send silly methods through to the API anyway, since they don't
+ * cause any harm.
+ *
+ * @param method an array of HTTP request methods passed in via CLI
+ * @returns a MethodFilter for use with the API
+ */
+function parseMethod(method: string[]): MethodFilter {
+  return { method };
+}
+
+/**
+ * Header filters can contain either just a key ("X-HEADER-KEY") or both
+ * a key and a value ("X-HEADER-KEY:some-value"). This function parses
+ * a given string according to that pattern.
+ *
+ * @param header a header string, "X-HEADER-KEY" or "X-HEADER-KEY:some-value"
+ * @returns a HeaderFilter for use with the API
+ */
+function parseHeader(header: string): HeaderFilter {
+  const [headerKey, headerQuery] = header.split(":", 2);
+
+  return {
+    header: {
+      key: headerKey.trim(),
+      query: headerQuery?.trim(),
+    },
+  };
+}
+
+/**
+ * A list of IPs can be passed in to filter for messages that come from
+ * a worker triggered by a request originating from one of those IPs.
+ * You can also pass in the string "self" to filter for the IP of the
+ * machine running `wrangler tail`.
+ *
+ * @param client_ip an array of IP addresses to filter
+ * @returns a ClientIPFilter for use with the API
+ */
+function parseIP(client_ip: string[]): ClientIPFilter {
+  return { client_ip };
+}
+
+/**
+ * Users can filter for logs that contain a "search" or a "query string".
+ * For example, if `--search findme` is passed to then we will only
+ * receive logs that contain the string "findme".
+ *
+ * @param query a query string to search for
+ * @returns a QueryFilter for use with the API
+ */
+function parseQuery(query: string): QueryFilter {
+  return { query };
+}

--- a/packages/partykit/src/tail/index.ts
+++ b/packages/partykit/src/tail/index.ts
@@ -1,0 +1,217 @@
+import type { Outcome } from "./filters";
+
+/**
+ * Everything captured by the trace worker and sent to us via
+ * `wrangler tail` is structured JSON that deserializes to this type.
+ */
+export type TailEventMessage = {
+  /**
+   * Whether the execution of this worker succeeded or failed
+   */
+  outcome: Outcome;
+
+  /**
+   * The name of the script we're tailing
+   */
+  scriptName?: string;
+
+  /**
+   * Any exceptions raised by the worker
+   */
+  exceptions: {
+    /**
+     * The name of the exception.
+     */
+    name: string;
+
+    /**
+     * The error message
+     */
+    message: unknown;
+
+    /**
+     * When the exception was raised/thrown
+     */
+    timestamp: number;
+  }[];
+
+  /**
+   * Any logs sent out by the worker
+   */
+  logs: {
+    message: unknown[];
+    level: string; // TODO: make this a union of possible values
+    timestamp: number;
+  }[];
+
+  /**
+   * When the event was triggered
+   */
+  eventTimestamp: number;
+
+  /**
+   * The event that triggered the worker. In the case of an HTTP request,
+   * this will be a RequestEvent. If it's a cron trigger, it'll be a
+   * ScheduledEvent. If it's a durable object alarm, it's an AlarmEvent.
+   * If it's a email, it'a an EmailEvent
+   *
+   * Until workers-types exposes individual types for export, we'll have
+   * to just re-define these types ourselves.
+   */
+  event:
+    | RequestEvent
+    | ScheduledEvent
+    | AlarmEvent
+    | EmailEvent
+    | undefined
+    | null;
+};
+
+/**
+ * A request that triggered worker execution
+ */
+
+export type RequestEvent = {
+  request: Pick<Request, "url" | "method" | "headers"> & {
+    /**
+     * Cloudflare-specific properties
+     * https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties
+     */
+    cf: {
+      /**
+       * How long (in ms) it took for the client's TCP connection to make a
+       * round trip to the worker and back. For all my gamers out there,
+       * this is the request's ping
+       */
+      clientTcpRtt?: number;
+
+      /**
+       * Longitude and Latitude of where the request originated from
+       */
+      longitude?: string;
+      latitude?: string;
+
+      /**
+       * What cipher was used to establish the TLS connection
+       */
+      tlsCipher: string;
+
+      /**
+       * Which continent the request came from.
+       */
+      continent?: "NA";
+
+      /**
+       * ASN of the incoming request
+       */
+      asn: number;
+
+      /**
+       * The country the incoming request is coming from
+       */
+      country?: string;
+
+      /**
+       * The TLS version the connection used
+       */
+      tlsVersion: string;
+
+      /**
+       * The colo that processed the request (i.e. the airport code
+       * of the closest city to the server that spun up the worker)
+       */
+      colo: string;
+
+      /**
+       * The timezone where the request came from
+       */
+      timezone?: string;
+
+      /**
+       * The city where the request came from
+       */
+      city?: string;
+
+      /**
+       * The browser-requested prioritization information in the request object
+       */
+      requestPriority?: string;
+
+      /**
+       * Which version of HTTP the request came over e.g. "HTTP/2"
+       */
+      httpProtocol: string;
+
+      /**
+       * The region where the request originated from
+       */
+      region?: string;
+      regionCode?: string;
+
+      /**
+       * The organization which owns the ASN of the incoming request, for example, Google Cloud.
+       */
+      asOrganization: string;
+
+      /**
+       * Metro code (DMA) of the incoming request, for example, "635".
+       */
+      metroCode?: string;
+
+      /**
+       * Postal code of the incoming request, for example, "78701".
+       */
+      postalCode?: string;
+    };
+  };
+};
+
+/**
+ * An event that was triggered at a certain time
+ */
+export type ScheduledEvent = {
+  /**
+   * The cron pattern that matched when this event fired
+   */
+  cron: string;
+
+  /**
+   * The time this worker was scheduled to run.
+   * For some reason, this doesn't...work correctly when we
+   * do it directly as a Date. So parse it later on your own.
+   */
+  scheduledTime: number;
+};
+
+/**
+ * A event that was triggered from a durable object alarm
+ */
+export type AlarmEvent = {
+  /**
+   * The datetime the alarm was scheduled for.
+   *
+   * This is sent as an ISO timestamp string (different than ScheduledEvent.scheduledTime),
+   * you should parse it later on on your own.
+   */
+  scheduledTime: string;
+};
+
+/**
+ * An event that was triggered from an email
+ */
+export type EmailEvent = {
+  /**
+   * Who sent the email
+   */
+  mailFrom: string;
+
+  /**
+   * Who was the email sent to
+   */
+  rcptTo: string;
+
+  /**
+   * Size of the email in bytes
+   */
+  rawSize: number;
+};

--- a/packages/partykit/src/tail/printing.ts
+++ b/packages/partykit/src/tail/printing.ts
@@ -1,0 +1,121 @@
+import type {
+  AlarmEvent,
+  EmailEvent,
+  RequestEvent,
+  ScheduledEvent,
+  TailEventMessage,
+} from "./";
+import type { Outcome } from "./filters";
+import type WebSocket from "ws";
+
+export function prettyPrintLogs(data: WebSocket.RawData): void {
+  const eventMessage: TailEventMessage = JSON.parse(data.toString());
+
+  if (isScheduledEvent(eventMessage.event)) {
+    const cronPattern = eventMessage.event.cron;
+    const datetime = new Date(
+      eventMessage.event.scheduledTime
+    ).toLocaleString();
+    const outcome = prettifyOutcome(eventMessage.outcome);
+
+    console.log(`"${cronPattern}" @ ${datetime} - ${outcome}`);
+  } else if (isRequestEvent(eventMessage.event)) {
+    const requestMethod = eventMessage.event?.request.method.toUpperCase();
+    const url = eventMessage.event?.request.url;
+    const outcome = prettifyOutcome(eventMessage.outcome);
+    const datetime = new Date(eventMessage.eventTimestamp).toLocaleString();
+
+    console.log(
+      url
+        ? `${requestMethod} ${url} - ${outcome} @ ${datetime}`
+        : `[missing request] - ${outcome} @ ${datetime}`
+    );
+  } else if (isEmailEvent(eventMessage.event)) {
+    const outcome = prettifyOutcome(eventMessage.outcome);
+    const datetime = new Date(eventMessage.eventTimestamp).toLocaleString();
+    const mailFrom = eventMessage.event.mailFrom;
+    const rcptTo = eventMessage.event.rcptTo;
+    const rawSize = eventMessage.event.rawSize;
+
+    console.log(
+      `Email from:${mailFrom} to:${rcptTo} size:${rawSize} @ ${datetime} - ${outcome}`
+    );
+  } else if (isAlarmEvent(eventMessage.event)) {
+    const outcome = prettifyOutcome(eventMessage.outcome);
+    const datetime = new Date(
+      eventMessage.event.scheduledTime
+    ).toLocaleString();
+
+    console.log(`Alarm @ ${datetime} - ${outcome}`);
+  } else {
+    // Unknown event type
+    const outcome = prettifyOutcome(eventMessage.outcome);
+    const datetime = new Date(eventMessage.eventTimestamp).toLocaleString();
+
+    console.log(`Unknown Event - ${outcome} @ ${datetime}`);
+  }
+
+  if (eventMessage.logs.length > 0) {
+    eventMessage.logs.forEach(({ level, message }) => {
+      console.log(`  (${level})`, ...message);
+    });
+  }
+
+  if (eventMessage.exceptions.length > 0) {
+    eventMessage.exceptions.forEach(({ name, message }) => {
+      console.error(`  ${name}:`, message);
+    });
+  }
+}
+
+export function jsonPrintLogs(data: WebSocket.RawData): void {
+  console.log(JSON.stringify(JSON.parse(data.toString()), null, 2));
+}
+
+function isRequestEvent(
+  event: TailEventMessage["event"]
+): event is RequestEvent {
+  return Boolean(event && "request" in event);
+}
+
+function isScheduledEvent(
+  event: TailEventMessage["event"]
+): event is ScheduledEvent {
+  return Boolean(event && "cron" in event);
+}
+
+function isEmailEvent(event: TailEventMessage["event"]): event is EmailEvent {
+  return Boolean(event && "mailFrom" in event);
+}
+
+/**
+ * Check to see if an event sent from a worker is an AlarmEvent.
+ *
+ * Because the only property on `AlarmEvent` is "scheduledTime", which it
+ * shares with `ScheduledEvent`, `isAlarmEvent` checks if there's _not_
+ * a "cron" property in `event` to confirm it's an alarm event.
+ *
+ * @param event An event
+ * @returns true if the event is an AlarmEvent
+ */
+function isAlarmEvent(event: TailEventMessage["event"]): event is AlarmEvent {
+  return Boolean(event && "scheduledTime" in event && !("cron" in event));
+}
+
+function prettifyOutcome(outcome: Outcome): string {
+  switch (outcome) {
+    case "ok":
+      return "Ok";
+    case "canceled":
+      return "Canceled";
+    case "exceededCpu":
+      return "Exceeded CPU Limit";
+    case "exceededMemory":
+      return "Exceeded Memory Limit";
+    case "exception":
+      return "Exception Thrown";
+    case "unknown":
+    default:
+      return "Unknown";
+  }
+}

--- a/packages/partykit/src/tests/tail.test.ts
+++ b/packages/partykit/src/tests/tail.test.ts
@@ -1,0 +1,54 @@
+import fs from "fs";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { clearMocks } from "./fetchResult-mock";
+import { tail } from "../cli";
+
+vi.mock("../fetchResult", async () => {
+  const { fetchResult } = await import("./fetchResult-mock");
+  return {
+    fetchResult,
+  };
+});
+
+process.env.GITHUB_LOGIN = "test-user";
+process.env.GITHUB_TOKEN = "test-token";
+
+const currDir = process.cwd();
+
+beforeEach(() => {
+  clearMocks();
+  // create a tmp dir
+  const dirPath = fs.mkdtempSync("pk-test-env");
+  // set the cwd to the tmp dir
+  process.chdir(dirPath);
+});
+
+afterEach(() => {
+  // switch back to the original dir
+  const tmpDir = process.cwd();
+  process.chdir(currDir);
+  // remove the tmp dir
+  fs.rmdirSync(tmpDir, { recursive: true });
+});
+
+describe("tail", () => {
+  it("should error without a project name", async () => {
+    await expect(
+      tail({
+        name: undefined,
+        config: undefined,
+        preview: undefined,
+        format: "pretty",
+        debug: false,
+        status: [],
+        header: undefined,
+        samplingRate: undefined,
+        method: [],
+        ip: [],
+        search: undefined,
+      })
+    ).rejects.toThrowErrorMatchingInlineSnapshot('"project name is missing"');
+  });
+
+  // TODO: test websocket stuff? maybe overkill for now.
+});


### PR DESCRIPTION
running `partykit tail --name <project>` will now hook into a project's production logs and stream them live. This is a full clone of `wrangler tail`. Two notes:
- there's a bug with cf where logs on websocket connections don't come through until the websocket disconnects
- the filter aren't tested yet

That said, this is a good start, so let's land it and see what to fix after.