### PR TITLE
fix: don't validate user tokens

### DIFF
--- a/.changeset/tender-cherries-hunt.md
+++ b/.changeset/tender-cherries-hunt.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+fix: don't validate user tokens
+
+This comments out `validateUserConfig`. We already had a bug where we weren't using it, but it's actually not that useful since we validate on the server anyway. So this patch comments out the implementation and usage.

--- a/packages/partykit/src/cli.ts
+++ b/packages/partykit/src/cli.ts
@@ -20,7 +20,7 @@ import {
   getConfig,
   getConfigPath,
   getUserConfig,
-  validateUserConfig,
+  // validateUserConfig,
 } from "./config";
 import type { TailFilterMessage } from "./tail/filters";
 import { translateCLICommandToFilterMessage } from "./tail/filters";
@@ -42,10 +42,13 @@ async function getUser() {
   let userConfig;
   try {
     userConfig = getUserConfig();
-    if (!validateUserConfig(userConfig)) {
-      throw new Error("Invalid user config");
-    }
+    // this isn't super useful since we're validating on the server
+    // if (!(await validateUserConfig(userConfig))) {
+    //   console.log("failed");
+    //   throw new Error("Invalid user config");
+    // }
   } catch (e) {
+    console.log("could not get user details, attempting to login");
     await fetchUserConfig();
     userConfig = getUserConfig();
   }

--- a/packages/partykit/src/config.ts
+++ b/packages/partykit/src/config.ts
@@ -35,22 +35,23 @@ export function getUserConfig(): UserConfig {
   return userConfigSchema.parse(config);
 }
 
-export async function validateUserConfig(config: UserConfig): Promise<boolean> {
-  const res = await fetch(`https://api.github.com/user`, {
-    headers: {
-      Authorization: `Bearer ${config.access_token}`,
-    },
-  });
-  if (
-    res.ok &&
-    config.login &&
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ((await res.json()) as any).login === config.login
-  ) {
-    return true;
-  }
-  return false;
-}
+// this isn't super useful since we're validating on the server
+// export async function validateUserConfig(config: UserConfig): Promise<boolean> {
+//   const res = await fetch(`https://api.github.com/user`, {
+//     headers: {
+//       Authorization: `Bearer ${config.access_token}`,
+//     },
+//   });
+//   if (
+//     res.ok &&
+//     config.login &&
+//     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+//     ((await res.json()) as any).login === config.login
+//   ) {
+//     return true;
+//   }
+//   return false;
+// }
 
 const GITHUB_APP_ID = "670a9f76d6be706f5209";
 


### PR DESCRIPTION
This comments out `validateUserConfig`. We already had a bug where we weren't using it, but it's actually not that useful since we validate on the server anyway. So this patch comments out the implementation and usage.