### PR TITLE
Add preview to deployed URL output

### DIFF
--- a/.changeset/rude-bulldogs-warn.md
+++ b/.changeset/rude-bulldogs-warn.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Add preview to deployed URL output.

--- a/packages/partykit/src/cli.ts
+++ b/packages/partykit/src/cli.ts
@@ -633,7 +633,9 @@ export async function deploy(options: {
   );
 
   console.log(
-    `Deployed ${config.main} as ${config.name}.${user.login}.partykit.dev`
+    `Deployed ${config.main} as ${
+      options.preview ? `${options.preview}.` : ""
+    }${config.name}.${user.login}.partykit.dev`
   );
 }
 


### PR DESCRIPTION
I noticed that the optional `preview` param wasn't included in the console log after a deployment.