### PR TITLE
Don't crash dev server on unhandled exceptions

### DIFF
--- a/.changeset/wise-sheep-beam.md
+++ b/.changeset/wise-sheep-beam.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Don't crash dev server on unhandled exceptions

--- a/packages/partykit/src/bin.ts
+++ b/packages/partykit/src/bin.ts
@@ -33,8 +33,7 @@ process.on("exit", (_code) => {
 });
 
 process.on("uncaughtExceptionMonitor", function (err) {
-  // console.error("uncaught exception", err);
-  throw err;
+  console.error("uncaught exception", err);
 });
 
 process.on("unhandledRejection", function (reason, _promise) {

--- a/packages/partykit/src/cli.ts
+++ b/packages/partykit/src/cli.ts
@@ -231,6 +231,15 @@ export async function dev(options: {
     );
   }
 
+  // Since we run the userspace code in this node process, we need to avoid
+  // unhandled exceptions crashing the dev server.
+  process.on("uncaughtException", function (err) {
+    console.error("uncaught exception", err);
+    rooms.forEach((room) => {
+      room.ws.clients.forEach((client) => client.close());
+    });
+  });
+
   // A map of room names to room servers.
   const rooms: Rooms = new Map();
 


### PR DESCRIPTION
Closes #116

Since we run the userspace code in the same node process that runs the `dev` command, any unhandled exception crashes that process. 

I’m not sure what the ideal behavior is. Maybe we should fork the websocket server that handles userspace code into a seperate processes and restart it so that all server-side state is reset? We don't really know _what_ causes the crash and it doesn't have to be related to a specific connection (i.e the combination of multiple connections could cause some invalid state).

For now, disconnecting all clients seems like a reasonable dev behavior. This should reset most of the state and let you know that something went wrong even if you're not looking at the console.