### PR TITLE
fix: extract room id correctly

### DIFF
--- a/.changeset/healthy-crabs-move.md
+++ b/.changeset/healthy-crabs-move.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+fix: extract room id correctly
+
+For `onRequest`, we were just using the part of the url after `/party` as the room id, which isn't true when we have query params. This quickly fixes that. Thanks @mellson for the catch.

--- a/packages/partykit/src/cli.ts
+++ b/packages/partykit/src/cli.ts
@@ -416,7 +416,9 @@ export async function dev(options: {
   }
 
   const app = createServer(async (req, res) => {
-    const roomId = getRoomIdFromPathname(req.url ?? "");
+    const url = new URL(req.url ?? "", `http://${req.headers.host}`);
+
+    const roomId = getRoomIdFromPathname(url.pathname);
     if (roomId === undefined) {
       // if (options.assets) {
       //  sirv(options.assets)(req, res)


### PR DESCRIPTION
For `onRequest`, we were just using the part of the url after `/party` as the room id, which isn't true when we have query params. This quickly fixes that. Thanks @mellson for the catch.