### PR TITLE
Remove source maps from bin

### DIFF
--- a/packages/partykit/src/bin.ts
+++ b/packages/partykit/src/bin.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --enable-source-maps
+#!/usr/bin/env node
 import * as cli from "./cli";
 import { fetchUserConfig, logout } from "./config";
 import { version } from "../package.json";


### PR DESCRIPTION
This PR is a mini-change. I noticed that we weren't able to develop our application using a dev container with `node --enable-source-maps`.

If you try to run `partykit dev` inside a dev container with source maps enabled it will throw ```/usr/bin/env: ‘node --enable-source-maps’: No such file or directory```.

I didn't dig much deeper than that because I could get it working by removing the source maps from the bin file.