### PR TITLE
Allow deploys by users with capitals in username

### DIFF
--- a/.changeset/thirty-guests-fetch.md
+++ b/.changeset/thirty-guests-fetch.md
@@ -1,0 +1,9 @@
+---
+"partykit": patch
+---
+
+Allow deploys by users with capitals in username
+
+This required a fix on the platform side, which I've deployed. It also required a cosmetic fix in the cli, which this patch does.
+
+Fix https://github.com/partykit/partykit/issues/137

--- a/packages/partykit/src/cli.ts
+++ b/packages/partykit/src/cli.ts
@@ -637,7 +637,7 @@ export async function deploy(options: {
   console.log(
     `Deployed ${config.main} as ${
       options.preview ? `${options.preview}.` : ""
-    }${config.name}.${user.login}.partykit.dev`
+    }${config.name}.${user.login.toLowerCase()}.partykit.dev`
   );
 }
 


### PR DESCRIPTION
This required a fix on the platform side, which I've deployed.   It also required a cosmetic fix in the cli, which this patch does.

Fix https://github.com/partykit/partykit/issues/137