### PR TITLE
feat: refactor PartyKitConnection / PartyKitRoom

### DIFF
--- a/.changeset/quick-guests-camp.md
+++ b/.changeset/quick-guests-camp.md
@@ -1,0 +1,12 @@
+---
+"partykit": patch
+---
+
+feat: refactor PartyKitConnection / PartyKitRoom
+
+This adds a couple of APIs based on common usage patterns:
+
+- `room.broadcast(message, without)` lets you broadcast a message to all connections to a room, optionally excluding an array of connection IDs
+- the "socket" now includes `.id`
+
+This shouldn't break any code, so I'm comfortable landing it.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -8,9 +8,11 @@ You can write a PartyKit entrypoint that looks like this:
 import { PartyKitServer, PartyKitRoom } from "partykit/server";
 
 export default {
-  async onConnect(ws: WebSocket, room: PartyKitRoom) {
-    ws.send("Hello, world!"); // Send a message to the client
-    ws.addEventListener("message", (event) => {
+  async onConnect(connection, room: PartyKitRoom) {
+    // `connection` is a WebSocket object, but with a few extra properties
+    // and methods. See the PartyKitConnection type for more details.
+    connection.send("Hello, world!"); // Send a message to the client
+    connection.addEventListener("message", (event) => {
       console.log(event.data); // Log a message from the client
     });
   },
@@ -20,13 +22,13 @@ export default {
 } satisfies PartyKitServer;
 ```
 
-**_onConnect_**: This function `onConnect` will be called whenever a new client (usually a browser, but it can be any device that can make WebSocket connections) connects to your project. The `ws` argument is a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) object that you can use to send and recieve messages to/from the client. The `room` argument is an object that contains information about the room that the client is in. It has the following properties:
+**_onConnect_**: This function `onConnect` will be called whenever a new client (usually a browser, but it can be any device that can make WebSocket connections) connects to your project. The `connection` argument is a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) object that you can use to send and recieve messages to/from the client (with a couple of additional properties). The `room` argument is an object that contains information about the room that the client is in. It has the following properties:
 
 **_id:_** _string_
 
 A string that uniquely identifies the room. This is usually associated with a single document, drawing, game session, or other collaborative experience. For example, if you're building a collaborative drawing app, this would be the id of the drawing that the client is currently viewing.
 
-**_connections_**: Map<string, {id: string, socket: WebSocket}>
+**_connections_**: Map<string, {id: string, socket: PartyKitConnection}>
 
 A Map of connection IDs to all the connections in the room. The ID is usually associated with a single client. For example, if you're building a collaborative drawing app, this would be the id of the user that's currently viewing the drawing. You can either specify this id yourself by passing a `_pk` query param in the WebSocket connection, or let PartyKit generate one for you.
 
@@ -125,7 +127,7 @@ With a configuration like that, you could then access the variable in your code 
 
 ```ts
 export default {
-  onConnect(ws, room) {
+  onConnect(connection, room) {
     console.log(room.env.MY_VAR); // "my value"
     console.log(room.env["some-nested-object"].a); // 123
   },
@@ -146,7 +148,7 @@ With a configuration like that, you could then access the variable in your code 
 
 ```ts
 export default {
-  onConnect(ws, room) {
+  onConnect(connection, room) {
     console.log(MY_CONSTANT); // "my value"
   },
 };

--- a/examples/persistence/src/server.ts
+++ b/examples/persistence/src/server.ts
@@ -1,35 +1,35 @@
 /// <reference no-default-lib="true"/>
 /// <reference types="@cloudflare/workers-types" />
 
-import type { PartyKitRoom, PartyKitServer } from "partykit/server";
-
-function broadcast(room: PartyKitRoom, msg: string) {
-  for (const ws of room.connections.values()) {
-    ws.socket.send(msg);
-  }
-}
+import type { PartyKitServer } from "partykit/server";
 
 export default {
   async onConnect(ws, room) {
     // your business logic here
     ws.send(`count:${(await room.storage.get("count")) || "0"}`);
 
-    ws.addEventListener("message", async function incoming(evt) {
+    async function incoming(evt) {
       if (evt.data === "increment") {
         await room.storage.put(
           "count",
           (parseInt(`${await room.storage.get("count")}`) || 0) + 1
         );
-        broadcast(room, `count:${(await room.storage.get("count")) || "0"}`);
+        room.broadcast(`count:${(await room.storage.get("count")) || "0"}`);
       } else if (evt.data === "decrement") {
         await room.storage.put(
           "count",
           (parseInt(`${await room.storage.get("count")}`) || 0) - 1
         );
-        broadcast(room, `count:${(await room.storage.get("count")) || "0"}`);
+        room.broadcast(`count:${(await room.storage.get("count")) || "0"}`);
       } else if ((evt.data as string).startsWith("latency")) {
         ws.send(evt.data);
       }
+    }
+
+    ws.addEventListener("message", (evt) => {
+      incoming(evt).catch((err) => {
+        console.error(err);
+      });
     });
   },
 } satisfies PartyKitServer;

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -6,12 +6,6 @@ import type {
   WebSocket,
 } from "@cloudflare/workers-types";
 
-export type PartyKitConnection = {
-  id: string;
-  socket: WebSocket;
-  unstable_initial: unknown;
-};
-
 export type PartyKitStorage = DurableObjectStorage;
 
 export type PartyKitRoom = {
@@ -20,10 +14,23 @@ export type PartyKitRoom = {
   connections: Map<string, PartyKitConnection>;
   env: Record<string, unknown>; // use a .env file, or --var
   storage: PartyKitStorage;
+  broadcast: (msg: string, without: string[]) => void;
+};
+
+export type PartyKitConnection = WebSocket & {
+  id: string;
+  /**
+   * @deprecated
+   */
+  socket: WebSocket;
+  unstable_initial: unknown;
 };
 
 export type PartyKitServer<Initial = unknown> = {
-  onConnect?: (ws: WebSocket, room: PartyKitRoom) => void | Promise<void>;
+  onConnect?: (
+    ws: PartyKitConnection,
+    room: PartyKitRoom
+  ) => void | Promise<void>;
 
   onBeforeConnect?: (
     req: Request,


### PR DESCRIPTION
This adds a couple of APIs based on common usage patterns:
- `room.broadcast(message, without)` lets you broadcast a message to all connections to a room, optionally excluding an array of connection IDs
- the "socket" now includes `.id`

This shouldn't break any code, so I'm comfortable landing it.