### PR TITLE
feat: incorporate hibernation api

### DIFF
--- a/.changeset/lemon-llamas-learn.md
+++ b/.changeset/lemon-llamas-learn.md
@@ -1,0 +1,8 @@
+---
+"partykit": patch
+---
+
+feat: optional hibernation api
+
+This introduces cloudflare's new hibernation api for durable objects. (see https://developers.cloudflare.com/workers/runtime-apis/durable-objects/#hahahugoshortcode-s2-hbhb)
+It kicks in when you specify `onMessage(){}` in the export. This should let us scale to thousands of connections on a single object, while also not charging for idle objects. Very nice.

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -15,6 +15,7 @@ export type PartyKitRoom = {
   env: Record<string, unknown>; // use a .env file, or --var
   storage: PartyKitStorage;
   broadcast: (msg: string, without: string[]) => void;
+  getWebSockets: () => WebSocket[];
 };
 
 export type PartyKitConnection = WebSocket & {
@@ -22,31 +23,50 @@ export type PartyKitConnection = WebSocket & {
   /**
    * @deprecated
    */
+  room: {
+    id: string;
+    internalID: string;
+    env: Record<string, unknown>;
+  };
   socket: WebSocket;
   unstable_initial: unknown;
 };
 
-export type PartyKitServer<Initial = unknown> = {
-  onConnect?: (
-    ws: PartyKitConnection,
-    room: PartyKitRoom
-  ) => void | Promise<void>;
+export type PartyKitServer<Initial = unknown> =
+  | {
+      onConnect?: (
+        ws: PartyKitConnection,
+        room: PartyKitRoom
+      ) => void | Promise<void>;
 
-  onBeforeConnect?: (
-    req: Request,
-    room: { id: string; env: Record<string, unknown> },
-    ctx: ExecutionContext
-  ) => Initial | Promise<Initial>;
+      onBeforeConnect?: (
+        req: Request,
+        room: { id: string; env: Record<string, unknown> },
+        ctx: ExecutionContext
+      ) => Initial | Promise<Initial>;
 
-  onBeforeRequest?: (
-    req: Request,
-    room: { id: string; env: Record<string, unknown> },
-    ctx: ExecutionContext
-  ) => Request | Promise<Request> | Response | Promise<Response>;
+      onBeforeRequest?: (
+        req: Request,
+        room: { id: string; env: Record<string, unknown> },
+        ctx: ExecutionContext
+      ) => Request | Promise<Request> | Response | Promise<Response>;
 
-  onRequest?: (
-    req: Request,
-    room: PartyKitRoom
-  ) => Response | Promise<Response>;
-  onAlarm?: (room: Omit<PartyKitRoom, "id">) => void | Promise<void>;
-};
+      onRequest?: (
+        req: Request,
+        room: PartyKitRoom
+      ) => Response | Promise<Response>;
+      onAlarm?: (room: Omit<PartyKitRoom, "id">) => void | Promise<void>;
+    }
+  | {
+      onMessage?: (
+        ws: PartyKitConnection,
+        message: string | ArrayBuffer,
+        room: PartyKitRoom
+      ) => void | Promise<void>;
+      onClose?: (ws: WebSocket, room: PartyKitRoom) => void | Promise<void>;
+      onError?: (
+        ws: PartyKitConnection,
+        err: Error,
+        room: PartyKitRoom
+      ) => void | Promise<void>;
+    };


### PR DESCRIPTION
This introduces cloudflare's new hibernation api for durable objects. (see https://developers.cloudflare.com/workers/runtime-apis/durable-objects/#hahahugoshortcode-s2-hbhb) It kicks in when you specify `onMessage(){}` in the export. This should let us scale to thousands of connections on a single object, while also not charging for idle objects. Very nice.

--- 

Creating a draft to start getting feedback, and building a demo in the meanwhile. 