### PR TITLE
feat: multiparty support

### DIFF
--- a/.changeset/rotten-pillows-hear.md
+++ b/.changeset/rotten-pillows-hear.md
@@ -1,0 +1,23 @@
+---
+"partykit": patch
+---
+
+feat: multiparty support
+
+Not all architectures can be represented with a single 'type' of entity. The interesting ones have multiple types of entities, interconnected by business logic. For example, you could model a chat system with a chatroom entity, a user entity, and a rate limiter entity. 
+
+This patch introduces "multiparty" support. You can define multiple modules with the same `PartyKitServer` interface in different modules, and configure them in `partykit.json`, like so: 
+
+```json
+main: "./src/main.ts" // your "main" entity, usually performing supervisory work
+parties: {
+  chatroom: "chatroom.ts",
+  user: "user.ts",
+  limiter: "rate-limiter.ts"
+}
+// ...
+```
+
+You can then reference these entities via `room.parties.<user/chatroom/limiter>.get('some-id')` and then make an http request to it with `.fetch(req)` or open a WebSocket to it with `.connect()`. 
+
+This needs more examples and documentation (and potentially iterating on the api), but let's land it to experiment with the model a little. 

--- a/examples/basic/partykit.json
+++ b/examples/basic/partykit.json
@@ -10,6 +10,9 @@
       "c": 3
     }
   },
+  "parties": {
+    "xyz": "./src/xyz.ts"
+  },
   "define": {
     "SOME_GLOBAL": "456666",
     "process.env.WHATUP": "\"what's up\""

--- a/examples/basic/src/server.ts
+++ b/examples/basic/src/server.ts
@@ -33,6 +33,13 @@ export default {
     console.log(room.env);
 
     console.log(process.env.WHATUP);
+    console.log(room.parties);
+    // const res = await room.parties.xyz.get("some-id").fetch();
+    // console.log("gottt", await res.text());
+    const wssss = room.parties.xyz.get("some-id").connect();
+    wssss.addEventListener("message", (evt) => {
+      console.log("got a message from xyz", evt.data);
+    });
 
     console.log(SOME_GLOBAL);
     return new Response(

--- a/examples/basic/src/xyz.ts
+++ b/examples/basic/src/xyz.ts
@@ -1,0 +1,14 @@
+/// <reference no-default-lib="true"/>
+/// <reference types="@cloudflare/workers-types" />
+
+import type { PartyKitServer } from "partykit/server";
+
+export default {
+  onRequest(_req: Request) {
+    return new Response("Hello from xyz");
+  },
+  onConnect(ws, _room) {
+    console.log("xyz connected");
+    ws.send("ping from xyz");
+  },
+} satisfies PartyKitServer;

--- a/packages/partykit/src/config.ts
+++ b/packages/partykit/src/config.ts
@@ -192,6 +192,7 @@ const configSchema = z
     assets: z.string().optional(),
     vars: z.record(z.unknown()).optional(),
     define: z.record(z.string()).optional(),
+    parties: z.record(z.string()).optional(),
     build: z
       .object({
         command: z.string().optional(),
@@ -353,6 +354,19 @@ export function getConfig(
         throw new Error(`Could not find main: ${parsedConfig.main}`);
       } else {
         config.main = "./" + path.relative(process.cwd(), absoluteMainPath);
+      }
+    }
+  }
+  if (config.parties) {
+    for (const [name, party] of Object.entries(config.parties)) {
+      const absolutePartyPath = path.isAbsolute(party)
+        ? party
+        : path.join(path.dirname(configPath), party);
+      if (!fs.existsSync(absolutePartyPath)) {
+        throw new Error(`Could not find party: ${party}`);
+      } else {
+        config.parties[name] =
+          "./" + path.relative(process.cwd(), absolutePartyPath);
       }
     }
   }

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -14,6 +14,15 @@ export type PartyKitRoom = {
   connections: Map<string, PartyKitConnection>;
   env: Record<string, unknown>; // use a .env file, or --var
   storage: PartyKitStorage;
+  parties: Record<
+    string,
+    {
+      get(id: string): {
+        connect: () => WebSocket;
+        fetch: () => Promise<Response>;
+      };
+    }
+  >;
   broadcast: (msg: string, without: string[]) => void;
 };
 


### PR DESCRIPTION
Not all architectures can be represented with a single 'type' of entity. The interesting ones have multiple types of entities, interconnected by business logic. For example, you could model a chat system with a chatroom entity, a user entity, and a rate limiter entity.

This patch introduces "multiparty" support. You can define multiple modules with the same `PartyKitServer` interface in different modules, and configure them in `partykit.json`, like so:

```js
{
  main: "./src/main.ts" // your "main" entity, usually performing supervisory work
  parties: {
    chatroom: "chatroom.ts",
    user: "user.ts",
    limiter: "rate-limiter.ts"
  }
// ...
}
```

You can then reference these entities via `room.parties.<user/chatroom/limiter>.get('some-id')` and then make an http request to it with `.fetch(req)` or open a WebSocket to it with `.connect()`.

This needs more examples and documentation (and potentially iterating on the api), but let's land it to experiment with the model a little.