### PR TITLE
Fixes empty `env` in dev mode

### DIFF
--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -39,6 +39,14 @@ let didWarnAboutMissingConnectionId = false;
 
 class PartyDurable {}
 
+type Env = {
+  [key: string]: DurableObjectNamespace;
+};
+
+type EnvWithVars = Env & {
+  vars: Record<string, unknown>;
+};
+
 function createDurable(Worker: PartyKitServer) {
   if (Worker.onConnect && typeof Worker.onConnect !== "function") {
     throw new Error(".onConnect is not a function");
@@ -63,18 +71,21 @@ function createDurable(Worker: PartyKitServer) {
   return class extends PartyDurable implements DurableObject {
     controller: DurableObjectState;
     room: PartyKitRoom;
-
-    constructor(controller: DurableObjectState, env: Env) {
+    namespaces: Record<string, DurableObjectNamespace>;
+    constructor(controller: DurableObjectState, env: EnvWithVars) {
       super();
-      this.controller = controller;
 
+      const { vars, ...namespaces } = env;
+
+      this.controller = controller;
+      this.namespaces = namespaces;
       this.room = {
         id: "UNDEFINED", // using a string here because we're guaranteed to have set it before we use it
         // TODO: probably want to rename this to something else
         // "sockets"? "connections"? "clients"?
         internalID: this.controller.id.toString(),
         connections: new Map(),
-        env: env,
+        env: vars,
         storage: this.controller.storage,
         parties: {},
         broadcast: this.broadcast,
@@ -92,8 +103,7 @@ function createDurable(Worker: PartyKitServer) {
     async fetch(request: Request) {
       const url = new URL(request.url);
       try {
-        for (const [key, v] of Object.entries(this.room.env)) {
-          const value = v as DurableObjectNamespace;
+        for (const [key, value] of Object.entries(this.namespaces)) {
           if (typeof value.idFromName === "function") {
             this.room.parties[key] ||= {
               get: (name: string) => {
@@ -234,10 +244,6 @@ export const MainDO = createDurable(Worker);
 
 __PARTIES__;
 declare const __PARTIES__: Record<string, string>;
-
-type Env = {
-  [key: string]: DurableObjectNamespace;
-};
 
 export default {
   async fetch(

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -40,9 +40,8 @@ let didWarnAboutMissingConnectionId = false;
 class PartyDurable {}
 
 // injected by esbuild in dev mode
-__ENV_VARS__;
-// vars can only be non-nullable json scalars
-declare const __ENV_VARS__: Record<string, string | number | boolean>;
+const envVars = __ENV_VARS__;
+declare const __ENV_VARS__: Record<string, unknown>;
 
 function createDurable(Worker: PartyKitServer) {
   if (Worker.onConnect && typeof Worker.onConnect !== "function") {
@@ -80,7 +79,7 @@ function createDurable(Worker: PartyKitServer) {
         // "sockets"? "connections"? "clients"?
         internalID: this.controller.id.toString(),
         connections: new Map(),
-        env: __ENV_VARS__,
+        env: envVars,
         storage: this.controller.storage,
         parties: {},
         broadcast: this.broadcast,

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -41,7 +41,8 @@ class PartyDurable {}
 
 // injected by esbuild in dev mode
 __ENV_VARS__;
-declare const __ENV_VARS__: Record<string, any>;
+// vars can only be non-nullable json scalars
+declare const __ENV_VARS__: Record<string, string | number | boolean>;
 
 function createDurable(Worker: PartyKitServer) {
   if (Worker.onConnect && typeof Worker.onConnect !== "function") {

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -67,13 +67,14 @@ function createDurable(Worker: PartyKitServer) {
     constructor(controller: DurableObjectState, env: Env) {
       super();
       this.controller = controller;
+
       this.room = {
         id: "UNDEFINED", // using a string here because we're guaranteed to have set it before we use it
         // TODO: probably want to rename this to something else
         // "sockets"? "connections"? "clients"?
         internalID: this.controller.id.toString(),
         connections: new Map(),
-        env,
+        env: env,
         storage: this.controller.storage,
         parties: {},
         broadcast: this.broadcast,

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -41,10 +41,8 @@ class PartyDurable {}
 
 type Env = {
   [key: string]: DurableObjectNamespace;
-};
-
-type EnvWithVars = Env & {
-  vars: Record<string, unknown>;
+} & {
+  PARTYKIT_VARS: Record<string, unknown>;
 };
 
 function createDurable(Worker: PartyKitServer) {
@@ -72,10 +70,10 @@ function createDurable(Worker: PartyKitServer) {
     controller: DurableObjectState;
     room: PartyKitRoom;
     namespaces: Record<string, DurableObjectNamespace>;
-    constructor(controller: DurableObjectState, env: EnvWithVars) {
+    constructor(controller: DurableObjectState, env: Env) {
       super();
 
-      const { vars, ...namespaces } = env;
+      const { PARTYKIT_VARS, ...namespaces } = env;
 
       this.controller = controller;
       this.namespaces = namespaces;
@@ -85,7 +83,7 @@ function createDurable(Worker: PartyKitServer) {
         // "sockets"? "connections"? "clients"?
         internalID: this.controller.id.toString(),
         connections: new Map(),
-        env: vars,
+        env: PARTYKIT_VARS,
         storage: this.controller.storage,
         parties: {},
         broadcast: this.broadcast,
@@ -289,7 +287,7 @@ export default {
                   request,
                   {
                     id: roomId,
-                    env,
+                    env: env.PARTYKIT_VARS,
                   },
                   ctx
                 );
@@ -331,7 +329,7 @@ export default {
                   request,
                   {
                     id: roomId,
-                    env,
+                    env: env.PARTYKIT_VARS,
                   },
                   ctx
                 );

--- a/packages/partykit/src/bin.tsx
+++ b/packages/partykit/src/bin.tsx
@@ -114,9 +114,6 @@ program
   .option("-n, --name <name>", "name of the project")
   .option("--preview [name]", "deploy to preview environment")
   .action(async (scriptPath, options) => {
-    if (options.withVars) {
-      console.warn("--with-vars is not yet implemented");
-    }
     await cli.deploy({
       main: scriptPath,
       name: options.name,

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -220,6 +220,10 @@ function useDev(options: DevProps): { inspectorUrl: string | undefined } {
                     `import ${name} from '${party}'; export const ${name}DO = createDurable(${name});`
                 )
                 .join("\n")
+            )
+            .replace(
+              "__ENV_VARS__",
+              `const __ENV_VARS__ = ${JSON.stringify(config.vars ?? {})}`
             ),
           resolveDir: process.cwd(),
           // TODO: setting a sourcefile name crashes the whole thing???

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -270,6 +270,7 @@ function useDev(options: DevProps): { inspectorUrl: string | undefined } {
                     compatibilityDate: "2021-05-26",
                     compatibilityFlags: ["nodejs_compat"],
                     port: config.port || 1999,
+                    bindings: config.vars,
                     durableObjects: {
                       MAIN_DO: "MainDO",
                       ...Object.entries(config.parties || {}).reduce<

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -270,7 +270,7 @@ function useDev(options: DevProps): { inspectorUrl: string | undefined } {
                     compatibilityFlags: ["nodejs_compat"],
                     port: config.port || 1999,
                     bindings: {
-                      vars: config.vars,
+                      PARTYKIT_VARS: config.vars,
                     },
                     durableObjects: {
                       MAIN_DO: "MainDO",

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -221,10 +221,7 @@ function useDev(options: DevProps): { inspectorUrl: string | undefined } {
                 )
                 .join("\n")
             )
-            .replace(
-              "__ENV_VARS__",
-              `const __ENV_VARS__ = ${JSON.stringify(config.vars ?? {})}`
-            ),
+            .replace("__ENV_VARS__", JSON.stringify(config.vars ?? {})),
           resolveDir: process.cwd(),
           // TODO: setting a sourcefile name crashes the whole thing???
           // sourcefile: "./" + path.relative(process.cwd(), scriptPath),

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -269,7 +269,9 @@ function useDev(options: DevProps): { inspectorUrl: string | undefined } {
                     compatibilityDate: "2021-05-26",
                     compatibilityFlags: ["nodejs_compat"],
                     port: config.port || 1999,
-                    bindings: config.vars,
+                    bindings: {
+                      vars: config.vars,
+                    },
                     durableObjects: {
                       MAIN_DO: "MainDO",
                       ...Object.entries(config.parties || {}).reduce<

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -220,8 +220,7 @@ function useDev(options: DevProps): { inspectorUrl: string | undefined } {
                     `import ${name} from '${party}'; export const ${name}DO = createDurable(${name});`
                 )
                 .join("\n")
-            )
-            .replace("__ENV_VARS__", JSON.stringify(config.vars ?? {})),
+            ),
           resolveDir: process.cwd(),
           // TODO: setting a sourcefile name crashes the whole thing???
           // sourcefile: "./" + path.relative(process.cwd(), scriptPath),


### PR DESCRIPTION
The migration to miniflare/workerd seems to have broken `room.env` in development mode. Instead of the `vars` sourced from partykit.json and `--var` flags, `room.env` was being defined as the facade's env (a `DurableObjectNamespace` map).

I've verified this approach works for both the main durable object and any other parties in a multiparty scenario.

I'm not 100% certain that this fix is the best way of achieving the desired outcome, feedback welcome!

 