### PR TITLE
fix: configure `_pk` with PartySocket with `options.id`

### DIFF
--- a/.changeset/unlucky-dodos-act.md
+++ b/.changeset/unlucky-dodos-act.md
@@ -1,0 +1,9 @@
+---
+"partysocket": patch
+---
+
+fix: configure `_pk` with PartySocket with `options.id`
+
+This adds an `id` config for `new PartySocket()` that's uses as the value of `_pk`, that becomes the connection id in the backend.
+
+Fixes https://github.com/partykit/partykit/issues/159

--- a/packages/partysocket/src/index.ts
+++ b/packages/partysocket/src/index.ts
@@ -5,6 +5,7 @@ export type PartySocketOptions = Omit<
   RWS.Options,
   "WebSocket" | "constructor"
 > & {
+  id?: string; // the id of the client
   host: string; // base url for the party
   room: string; // the room to connect to
   protocol?: string;
@@ -51,7 +52,7 @@ export default class PartySocket extends ReconnectingWebSocket {
   constructor(readonly partySocketOptions: PartySocketOptions) {
     const { host, room, protocol, query, protocols, ...socketOptions } =
       partySocketOptions;
-    const _pk = generateUUID();
+    const _pk = partySocketOptions.id || generateUUID();
     let url = `${
       protocol ||
       (host.startsWith("localhost:") || host.startsWith("127.0.0.1:")


### PR DESCRIPTION
This adds an `id` config for `new PartySocket()` that's uses as the value of `_pk`, that becomes the connection id in the backend.

Fixes https://github.com/partykit/partykit/issues/159