### PR TITLE
Replace room.getWebSockets with a shimmed room.connections when using Hibernation API

### DIFF
--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -24,7 +24,6 @@ export type PartyKitRoom = {
     }
   >;
   broadcast: (msg: string, without: string[]) => void;
-  getWebSockets: () => WebSocket[];
 };
 
 export type PartyKitConnection = WebSocket & {


### PR DESCRIPTION
_Note: This PR is stacked on top of #157_

Replaces the new `room.getWebSockets` with a `room.connections` property that behaves like the `connections` map we currently use in `onConnect`. Along with moving the Room ID back onto the `room` property in https://github.com/partykit/partykit/pull/157/commits/1f0c4c66e9856bf0c503ecd00b1af06a3ec5e22a, this now makes the Connection and Room APIs identical between `onMessage` and `onConnect`.

Opening PR for early comments. This seems to work correctly in dev mode, but I still need to implement the same behaviour on the platform side. 

