### PR TITLE
feat: add `ctx` to `onConnect`

### DIFF
--- a/.changeset/tough-pandas-shout.md
+++ b/.changeset/tough-pandas-shout.md
@@ -30,7 +30,7 @@ export default {
     connection.serializeAttachment({ ip });
     // do something with the ip
   },
-  onMessage(message, connection, room) {
+  onMessage(connection, message, room) {
     const { ip } = connection.deserializeAttachment();
     // do something with the ip
   },

--- a/.changeset/tough-pandas-shout.md
+++ b/.changeset/tough-pandas-shout.md
@@ -1,0 +1,40 @@
+---
+"partykit": patch
+---
+
+feat: add `ctx` to `onConnect`
+
+## `onConnect(connection, room, context){}`
+
+Developers want access to additional metadata available on every connection. For example, to implement a rate limiter, they need access to the IP address of the client. They may want access to the user agent, some cookie values, or any of the special `cf` properties like geo information, etc. Most of this information is available on the request object when the connection is made, but we don't actually expose that to the developer right now. I propose we do that.
+
+We can expose a third parameter to the `onConnect` method that is the `context` object. For now it'll just be an onject with a single property `request` that is the request object. In the future we can add more properties to this object.
+
+```js
+onConnect(connection, room, context) {
+  const { request } = context;
+  const { headers } = request;
+  const ip = headers['x-forwarded-for'];
+  // do something with the ip
+}
+```
+
+Now, the hibernation api variant doesn't include `onConnect` at all. So, we'll need to add that to the hibernation api. So, I also propose that we let folks add an optional `onConnect` method when defining a party. Calling `connection.addEventListener` with that variant will silently do nothing, but maybe we could override that to throw an error instead. Importantly, folks should be able to call `.serializeAttachment` in the `onConnect` method, and recover that data in the `onMessage` method.
+
+```js
+export default {
+  onConnect(connection, room, context) {
+    const { request } = context;
+    const { headers } = request;
+    const ip = headers["x-forwarded-for"];
+    connection.serializeAttachment({ ip });
+    // do something with the ip
+  },
+  onMessage(message, connection, room) {
+    const { ip } = connection.deserializeAttachment();
+    // do something with the ip
+  },
+};
+```
+
+This PR adds the context object to `onConnect`. After we land the hibernation api, we can do the additional work mentioned.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -5,10 +5,10 @@ The PartyKit runtime is a modern standards-based JavaScript runtime based on the
 You can write a PartyKit entrypoint that looks like this:
 
 ```ts
-import { PartyKitServer, PartyKitRoom } from "partykit/server";
+import { PartyKitServer, PartyKitRoom, PartyKitContext } from "partykit/server";
 
 export default {
-  async onConnect(connection, room: PartyKitRoom) {
+  async onConnect(connection, room: PartyKitRoom, ctx: PartyKitContext) {
     // `connection` is a WebSocket object, but with a few extra properties
     // and methods. See the PartyKitConnection type for more details.
     connection.send("Hello, world!"); // Send a message to the client
@@ -22,7 +22,9 @@ export default {
 } satisfies PartyKitServer;
 ```
 
-**_onConnect_**: This function `onConnect` will be called whenever a new client (usually a browser, but it can be any device that can make WebSocket connections) connects to your project. The `connection` argument is a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) object that you can use to send and recieve messages to/from the client (with a couple of additional properties). The `room` argument is an object that contains information about the room that the client is in. It has the following properties:
+**_onConnect_**: This function `onConnect` will be called whenever a new client (usually a browser, but it can be any device that can make WebSocket connections) connects to your project. The `connection` argument is a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) object that you can use to send and recieve messages to/from the client (with a couple of additional properties).
+
+The `room` argument is an object that contains information about the room that the client is in. It has the following properties:
 
 **_id:_** _string_
 
@@ -41,6 +43,12 @@ A map of all the environment variables that you've set for your project. See the
 **_internalID_**: _string_
 
 This too is a string that uniquely identifies the room, but it's not meant to be directly used by your application. It's used internally by the PartyKit platform to identify the room.
+
+The `ctx` argument is an object that contains information about the runtime environment. It has the following properties:
+
+**_request_**: _Request_
+
+A [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object that contains information about the HTTP request that initiated the WebSocket connection. This is useful if you want to get information about the client that's connecting to your project. For example, you can get the IP address of the client like this: `ctx.request.headers.get('cf-connecting-ip')`
 
 From a client (like your browser app), you can connect to the server like this:
 

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -9,6 +9,7 @@ import type {
   PartyKitServer,
   PartyKitRoom,
   PartyKitConnection,
+  PartyKitContext,
 } from "../src/server";
 import type {
   DurableObjectNamespace,
@@ -187,7 +188,7 @@ function createDurable(Worker: PartyKitServer) {
         // Accept the websocket connection
         serverWebSocket.accept();
 
-        await this.handleConnection(this.room, connection);
+        await this.handleConnection(this.room, connection, { request });
 
         return new Response(null, { status: 101, webSocket: clientWebSocket });
       } catch (e) {
@@ -204,7 +205,11 @@ function createDurable(Worker: PartyKitServer) {
       }
     }
 
-    async handleConnection(room: PartyKitRoom, connection: PartyKitConnection) {
+    async handleConnection(
+      room: PartyKitRoom,
+      connection: PartyKitConnection,
+      context: PartyKitContext
+    ) {
       assert(
         "onConnect" in Worker && typeof Worker.onConnect === "function",
         "No onConnect handler"
@@ -227,7 +232,7 @@ function createDurable(Worker: PartyKitServer) {
 
       // and finally, connect the client to the worker
       // TODO: pass room id here? and other meta
-      return Worker.onConnect(connection, room);
+      return Worker.onConnect(connection, room, context);
     }
 
     async alarm() {

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -8,6 +8,10 @@ import type {
 
 export type PartyKitStorage = DurableObjectStorage;
 
+export type PartyKitContext = {
+  request: Request;
+};
+
 export type PartyKitRoom = {
   id: string; // room id, usually a slug
   internalID: string; // internal id
@@ -38,7 +42,8 @@ export type PartyKitConnection = WebSocket & {
 export type PartyKitServer<Initial = unknown> = {
   onConnect?: (
     ws: PartyKitConnection,
-    room: PartyKitRoom
+    room: PartyKitRoom,
+    ctx: PartyKitContext
   ) => void | Promise<void>;
 
   onBeforeConnect?: (


### PR DESCRIPTION
## `onConnect(connection, room, context){}`

Developers want access to additional metadata available on every connection. For example, to implement a rate limiter, they need access to the IP address of the client. They may want access to the user agent, some cookie values, or any of the special `cf` properties like geo information, etc. Most of this information is available on the request object when the connection is made, but we don't actually expose that to the developer right now. I propose we do that.

We can expose a third parameter to the `onConnect` method that is the `context` object. For now it'll just be an onject with a single property `request` that is the request object. In the future we can add more properties to this object.

```js
onConnect(connection, room, context) {
  const { request } = context;
  const { headers } = request;
  const ip = headers['x-forwarded-for'];
  // do something with the ip
}
```

Now, the hibernation api variant doesn't include `onConnect` at all. So, we'll need to add that to the hibernation api. So, I also propose that we let folks add an optional `onConnect` method when defining a party. Calling `connection.addEventListener` with that variant will silently do nothing, but maybe we could override that to throw an error instead. Importantly, folks should be able to call `.serializeAttachment` in the `onConnect` method, and recover that data in the `onMessage` method.

```js
export default {
  onConnect(connection, room, context) {
    const { request } = context;
    const { headers } = request;
    const ip = headers["x-forwarded-for"];
    connection.serializeAttachment({ ip });
    // do something with the ip
  },
  onMessage(message, connection, room) {
    const { ip } = connection.deserializeAttachment();
    // do something with the ip
  },
};
```

This PR adds the context object to `onConnect`. After we land the hibernation api, we can do the additional work mentioned.