### PR TITLE
feat: persist state locally in dev

### DIFF
--- a/.changeset/giant-clouds-itch.md
+++ b/.changeset/giant-clouds-itch.md
@@ -1,0 +1,9 @@
+---
+"partykit": patch
+---
+
+feat: persist state locally in dev
+
+Currently, `.storage` is only held in memory. This is fine for most usecases, but it means if you shutdown the dev process, we lose any state you may have been holding. This PR adds a config/flag `persist` to store this locally. We also turn it on by default. You can pass `--persist false` in the cli, or `persist: false` in config to turn it off (or `true` for default path). You can also pass `--persist some/custom/path` in the cli, or `persist: "some/custom/path" in the config, to use a custom path for the state.
+
+Fixes https://github.com/partykit/partykit/issues/161

--- a/.gitignore
+++ b/.gitignore
@@ -129,5 +129,6 @@ dist
 
 # More stuff 
 .DS_Store
-
 TODO.md
+.partykit
+

--- a/packages/partykit/src/bin.tsx
+++ b/packages/partykit/src/bin.tsx
@@ -73,6 +73,9 @@ program
   .option("-p, --port <number>", "port to run the server on")
   .option("--assets <path>", "path to assets directory")
   .option("-c, --config <path>", "path to config file")
+  .addOption(
+    new Option("--persist [path]", "persist local state").default(true)
+  )
   // .option("-e, --env", "environment to use")
   .option(
     "-v, --var [vars...]",
@@ -87,6 +90,7 @@ program
       <Dev
         main={scriptPath}
         port={options.port}
+        persist={options.persist}
         config={options.config}
         vars={getArrayKVOption(options.var)}
         define={getArrayKVOption(options.define)}

--- a/packages/partykit/src/config.ts
+++ b/packages/partykit/src/config.ts
@@ -194,6 +194,7 @@ const configSchema = z
     main: z.string().optional(),
     port: z.number().optional(),
     assets: z.string().optional(),
+    persist: z.union([z.boolean(), z.string()]).optional(),
     vars: z.record(z.unknown()).optional(),
     define: z.record(z.string()).optional(),
     parties: z.record(z.string()).optional(),


### PR DESCRIPTION
Currently, `.storage` is only held in memory. This is fine for most usecases, but it means if you shutdown the dev process, we lose any state you may have been holding. This PR adds a config/flag `persist` to store this locally. We also turn it on by default. You can pass `--persist false` in the cli, or `persist: false` in config to turn it off (or `true` for default path). You can also pass `--persist some/custom/path` in the cli, or `persist: "some/custom/path" in the config, to use a custom path for the state.

Fixes https://github.com/partykit/partykit/issues/161