### PR TITLE
Allow user to respond with Fetch API Response

### DIFF
--- a/.changeset/quick-knives-exercise.md
+++ b/.changeset/quick-knives-exercise.md
@@ -1,0 +1,11 @@
+---
+"partykit": patch
+---
+
+Fix Response types for `onBeforeRequest` and `onRequest` callbacks.
+
+When you respond from `onBeforeRequest` or `onRequest`, you have to construct a new response using the `new Response()`. 
+
+Unless you've overridden the global `Response` type to refer to `"@cloudflare/workers-types"`, the type is assumed a [Fetch API Response](https://developer.mozilla.org/en-US/docs/Web/API/Response). This is a pain in the ass, especially if you have your PartyKit server code as part of your frontend project.
+
+Because the actual return value will be an instance of whatever Response class is defined in the environment, the type does not matter to us, so let's just allow the user to return either type.


### PR DESCRIPTION
## Problem

Fix Response types for `onBeforeRequest` and `onRequest` callbacks.

When you respond from `onBeforeRequest` or `onRequest`, you have to construct a new response using the `new Response()`. 

Unless you've overridden the global `Response` type to refer to `"@cloudflare/workers-types"`, the type is assumed a [Fetch API Response](https://developer.mozilla.org/en-US/docs/Web/API/Response). This is a pain in the ass, especially if you have your PartyKit server code as part of your frontend project.

<img width="838" alt="image" src="https://github.com/partykit/partykit/assets/1203949/7df18b4a-1df3-46ce-889f-9a5187baa24c">

## Solution

Because the actual return value will be an instance of whatever Response class is defined in the environment, the type does not matter to us, so let's just allow the user to return either type.

## Notes

We'll need to do the same for `Request` when landing #178.



