### PR TITLE
Install @cloudflare/workers-types transitively

### DIFF
--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -12,6 +12,7 @@
     "./src/cli": "./src/cli.ts"
   },
   "dependencies": {
+    "@cloudflare/workers-types": "^4.20230628.0",
     "chalk": "^5.2.0",
     "chokidar": "^3.5.3",
     "clipboardy": "^3.0.0",
@@ -38,7 +39,6 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20230628.0",
     "@types/execa": "^2.0.0",
     "@types/find-config": "^1.0.1",
     "@types/http-proxy": "^1.17.10",


### PR DESCRIPTION
## Problem

The `PartyKitConnection` type resolves to `any` unless the consumer has installed `@cloudflare/workers-types` definitions:

<img width="657" alt="image" src="https://github.com/partykit/partykit/assets/1203949/03548f2e-7b1b-4534-aa8b-591ed9ed8eb6">

This is because the type extends the `WebSocket` type, which won't be available unless the type definitions are installed:

```
import type { DurableObjectStorage, ExecutionContext, Request, Response, WebSocket } from "@cloudflare/workers-types";

export type PartyKitConnection = WebSocket & {
    id: string;
    /**
     * @deprecated
     */
    socket: WebSocket;
    unstable_initial: unknown;
};
```

## Solution

Move `@cloudflare/workers-types` from `devDependencies` to `dependencies` to ensure they're installed in client projects.
