### PR TITLE
feat: add support for headers in callback options

### DIFF
--- a/packages/y-partykit/src/index.ts
+++ b/packages/y-partykit/src/index.ts
@@ -203,6 +203,8 @@ async function getYDoc(
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
+                ...(callback.headers 
+                    && Object.fromEntries(callback.headers)),
               },
               body: JSON.stringify(dataToSend),
               signal: AbortSignal.timeout(
@@ -366,6 +368,7 @@ interface HandlerCallbackOptions extends CallbackOptions {
 interface UrlCallbackOptions extends CallbackOptions {
   handler?: never;
   url: string;
+  headers?: Headers;
 }
 
 type YPartyKitCallbackOptions = HandlerCallbackOptions | UrlCallbackOptions;


### PR DESCRIPTION
When a user needs to add headers to the callback (ex authentication headers), currently they have to write a handler function that requests the receiving server. 

This PR adds an simpler way to implement something of the sort: it adds a `header` option in the interface UrlCallbackOptions` where a user can specify Headers to be added to the callback request.