### PR TITLE
fix: change type of `conn` to PartykitConenection

### DIFF
--- a/.changeset/rude-buses-fix.md
+++ b/.changeset/rude-buses-fix.md
@@ -1,0 +1,5 @@
+---
+"y-partykit": patch
+---
+
+fix: change type of `conn` to PartykitConenection


### PR DESCRIPTION
Currently the type of `conn` for onConnect in y-partykit is WebSocket, which is incompatible with the type definition of onConnect of `partykit/server`.

This PR replaces the type of the connections in `y-partykit` to the correct type.