### PR TITLE
Clean up hibernatable connection before invoking event handler

### DIFF
--- a/.changeset/sharp-dancers-turn.md
+++ b/.changeset/sharp-dancers-turn.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Clean up hibernatable connection before invoking event handler

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -294,18 +294,20 @@ function createDurable(Worker: PartyKitServer) {
 
     async webSocketClose(ws: WebSocket) {
       const connection: PartyKitConnection = rehydrateHibernatedConnection(ws);
+      this.room.connections.delete(connection.id);
+
       if ("onClose" in Worker && typeof Worker.onClose === "function") {
         return Worker.onClose(connection, this.room);
       }
-      this.room.connections.delete(connection.id);
     }
 
     async webSocketError(ws: WebSocket, err: Error) {
       const connection: PartyKitConnection = rehydrateHibernatedConnection(ws);
+      this.room.connections.delete(connection.id);
+
       if ("onError" in Worker && typeof Worker.onError === "function") {
         return Worker.onError(connection, err, this.room);
       }
-      this.room.connections.delete(connection.id);
     }
 
     async alarm() {


### PR DESCRIPTION
Fixes issue where `connections` keeps growing on every connection when opting into Durable Object Hibernation.