### PR TITLE
Improve PartySocket types and React hooks API

### DIFF
--- a/.changeset/proud-seas-smile.md
+++ b/.changeset/proud-seas-smile.md
@@ -1,0 +1,8 @@
+---
+"partysocket": patch
+---
+
+Improve PartySocket types and React hooks API:
+* Add websocket lifecycle event handlers to usePartyKit options to reduce need for effects in userland
+* Allow usePartySocket to provide startClosed option to initialize without opening connection
+* Fix types for PartySocket#removeEventListener

--- a/packages/partysocket/src/react.ts
+++ b/packages/partysocket/src/react.ts
@@ -9,15 +9,23 @@ export default function usePartySocket(options: PartySocketOptions) {
   const socketRef = useRef<PartySocket>(
     new PartySocket({
       ...options,
-      startClosed: true,
+      startClosed: true, // only connect on mount
     })
   );
-  useEffect(() => {
-    socketRef.current.reconnect();
-    return () => {
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      socketRef.current.close();
-    };
-  }, []);
+
+  useEffect(
+    () => {
+      if (options.startClosed !== true) {
+        socketRef.current.reconnect();
+      }
+
+      return () => {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        socketRef.current.close();
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
   return socketRef.current;
 }

--- a/packages/partysocket/src/react.ts
+++ b/packages/partysocket/src/react.ts
@@ -4,24 +4,51 @@ import { useEffect, useRef } from "react";
 import type { PartySocketOptions } from ".";
 import PartySocket from ".";
 
+type UsePartySocketOptions = PartySocketOptions & {
+  onOpen?: (event: WebSocketEventMap["open"]) => void;
+  onMessage?: (event: WebSocketEventMap["message"]) => void;
+  onClose?: (event: WebSocketEventMap["close"]) => void;
+  onError?: (event: WebSocketEventMap["error"]) => void;
+};
+
 // A React hook that wraps PartySocket
-export default function usePartySocket(options: PartySocketOptions) {
+export default function usePartySocket(options: UsePartySocketOptions) {
+  const { onOpen, onMessage, onClose, onError, ...partySocketOptions } =
+    options;
+
   const socketRef = useRef<PartySocket>(
     new PartySocket({
-      ...options,
+      ...partySocketOptions,
       startClosed: true, // only connect on mount
     })
   );
 
+  // note: this effect must be defined before the auto-connect effect below
+  useEffect(() => {
+    const socket = socketRef.current;
+    if (onOpen) socket.addEventListener("open", onOpen);
+    if (onClose) socket.addEventListener("close", onClose);
+    if (onError) socket.addEventListener("error", onError);
+    if (onMessage) socket.addEventListener("message", onMessage);
+
+    return () => {
+      if (onOpen) socket.removeEventListener("open", onOpen);
+      if (onClose) socket.removeEventListener("close", onClose);
+      if (onError) socket.removeEventListener("error", onError);
+      if (onMessage) socket.removeEventListener("message", onMessage);
+    };
+  }, [onOpen, onMessage, onClose, onError]);
+
+  // note: this effect must be defined after the event listener registration above
   useEffect(
     () => {
+      const socket = socketRef.current;
       if (options.startClosed !== true) {
-        socketRef.current.reconnect();
+        socket.reconnect();
       }
 
       return () => {
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        socketRef.current.close();
+        socket.close();
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/partysocket/src/type-helper.ts
+++ b/packages/partysocket/src/type-helper.ts
@@ -17,4 +17,18 @@ interface IntermediateEventTarget<EventMap> extends EventTarget {
     callback: EventListenerOrEventListenerObject | null,
     options?: EventListenerOptions | boolean
   ): void;
+
+  removeEventListener<K extends keyof EventMap>(
+    type: K,
+    callback: (
+      event: EventMap[K] extends Event ? EventMap[K] : never
+    ) => EventMap[K] extends Event ? void : never,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: EventListenerOptions | boolean
+  ): void;
 }


### PR DESCRIPTION
* Add websocket lifecycle event handlers to `usePartyKit` options to reduce need for effects in userland
* Allow `usePartySocket` to provide `startClosed` option to initialize without opening connection
* Fix types for `PartySocket#removeEventListener`

Example:

```tsx
  const [messages, setMessages] = useState<string[]>([]);
  const socket = usePartySocket({
    host: "localhost:1999",
    room: "chat-room",
    startClosed: true,
    onOpen() {
      setMessages((messages) => [...messages, "Joined"]);
    },
    onMessage(event) {
      setMessages((messages) => [...messages, event.data]);
    },
  });

  return (
    <button onClick={() => socket.reconnect()}>Open</button>
  )
```