### PR TITLE
cache `parties` object arter creating it

### DIFF
--- a/.changeset/giant-apricots-reply.md
+++ b/.changeset/giant-apricots-reply.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+cache `parties` object arter creating it
+
+Let's not create the `parties` object on every request/connection, and instead cache it after first creating it.


### PR DESCRIPTION
Let's not create the `parties` object on every request/connection, and instead cache it after first creating it.