### PR TITLE
cache hydrated connections

### DIFF
--- a/.changeset/warm-bears-behave.md
+++ b/.changeset/warm-bears-behave.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+cache hydrated connections
+
+When using hibernation, we should cache initialised connections, or else we end up doing it for every message, which seems wasteful.

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -36,13 +36,20 @@ function getRoomIdFromPathname(pathname: string) {
   }
 }
 
-function rehydrateHibernatedConnection(ws: WebSocket): PartyKitConnection {
-  return Object.assign(ws, {
-    ...(ws.deserializeAttachment() as PartyKitConnection),
-    socket: ws,
-  });
-}
+const rehydratedConnections = new WeakMap<WebSocket, PartyKitConnection>();
 
+function rehydrateHibernatedConnection(ws: WebSocket): PartyKitConnection {
+  if (rehydratedConnections.has(ws)) {
+    return rehydratedConnections.get(ws) as PartyKitConnection;
+  }
+  const connection = Object.assign(ws, {
+    ...ws.deserializeAttachment(),
+    socket: ws,
+  }) as PartyKitConnection;
+
+  rehydratedConnections.set(ws, connection);
+  return connection;
+}
 let didWarnAboutMissingConnectionId = false;
 
 class PartyDurable {}


### PR DESCRIPTION
When using hibernation, we should cache initialised connections, or else we end up doing it for every message, which seems wasteful.