### PR TITLE
fix: make PartySocket work inside cloudflare/partykit

### DIFF
--- a/.changeset/few-houses-notice.md
+++ b/.changeset/few-houses-notice.md
@@ -1,0 +1,7 @@
+---
+"partysocket": patch
+---
+
+fix: make PartySocket work inside cloudflare/partykit
+
+The implementation of `ReconnectingWebSocket` tests whether a WebSocket class is valid by the presence of a static field that's not available on CF's/PK's WebSocket class. It's a bit much anyway, so we just remove the test.

--- a/packages/partysocket/src/tests/reconnecting.test.ts
+++ b/packages/partysocket/src/tests/reconnecting.test.ts
@@ -58,19 +58,19 @@ afterAll(() => {
 //   }).toThrow();
 // });
 
-test("throws with missing constructor", () => {
-  delete (global as any).WebSocket;
-  expect(() => {
-    new ReconnectingWebSocket(URL, undefined, { maxRetries: 0 });
-  }).toThrow();
-});
+// test("throws with missing constructor", () => {
+//   delete (global as any).WebSocket;
+//   expect(() => {
+//     new ReconnectingWebSocket(URL, undefined, { maxRetries: 0 });
+//   }).toThrow();
+// });
 
-test("throws with non-constructor object", () => {
-  (global as any).WebSocket = {};
-  expect(() => {
-    new ReconnectingWebSocket(URL, undefined, { maxRetries: 0 });
-  }).toThrow();
-});
+// test("throws with non-constructor object", () => {
+//   (global as any).WebSocket = {};
+//   expect(() => {
+//     new ReconnectingWebSocket(URL, undefined, { maxRetries: 0 });
+//   }).toThrow();
+// });
 
 test("throws if not created with `new`", () => {
   expect(() => {

--- a/packages/partysocket/src/ws.ts
+++ b/packages/partysocket/src/ws.ts
@@ -49,19 +49,6 @@ function assert(condition: unknown, msg?: string): asserts condition {
   }
 }
 
-/**
- * Returns true if given argument looks like a WebSocket class
- */
-function isWebSocket(w: unknown): w is WebSocket {
-  return (
-    typeof w !== "undefined" &&
-    !!w &&
-    typeof w === "function" &&
-    "CLOSING" in w &&
-    w.CLOSING === 2
-  );
-}
-
 function cloneEvent(e: Event) {
   return new (e as any).constructor(e.type, e) as Event;
 }
@@ -413,9 +400,7 @@ export default class ReconnectingWebSocket extends (EventTarget as TypedEventTar
 
     this._debug("connect", this._retryCount);
     this._removeListeners();
-    if (!isWebSocket(WebSocket)) {
-      throw Error("No valid WebSocket class provided");
-    }
+
     this._wait()
       .then(() =>
         Promise.all([


### PR DESCRIPTION
The implementation of `ReconnectingWebSocket` tests whether a WebSocket class is valid by the presence of a static field that's not available on CF's/PK's WebSocket class. It's a bit much anyway, so we just remove the test.