### PR TITLE
disable inspector for tests

### DIFF
--- a/.changeset/tough-dots-hunt.md
+++ b/.changeset/tough-dots-hunt.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+disable inspector for tests
+
+The server we spin up makes our tests flaky. we don't have tests for dev logs anyway right now, so let's disable them.

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -143,6 +143,7 @@ export type DevProps = {
   compatibilityDate?: string;
   compatibilityFlags?: string[] | undefined;
   minify?: boolean | undefined;
+  enableInspector?: boolean | undefined;
 };
 
 export function Dev(props: DevProps) {
@@ -156,9 +157,15 @@ export function Dev(props: DevProps) {
 function DevImpl(props: DevProps) {
   const { inspectorUrl } = useDev(props);
 
+  return props.enableInspector ? (
+    <Inspector inspectorUrl={inspectorUrl} />
+  ) : null;
+}
+
+function Inspector(props: { inspectorUrl: string | undefined }) {
   useInspector({
     port: 9230,
-    inspectorUrl,
+    inspectorUrl: props.inspectorUrl,
     logToTerminal: true,
     sourceMapPath: undefined,
     sourceMapMetadata: undefined,

--- a/packages/partykit/src/tests/dev.test.tsx
+++ b/packages/partykit/src/tests/dev.test.tsx
@@ -27,6 +27,7 @@ async function runDev(props: DevProps) {
         }}
       >
         <Dev
+          enableInspector={false}
           {...props}
           onReady={() => {
             resolve();
@@ -53,7 +54,7 @@ describe("dev", () => {
     );
   });
 
-  it.skip("should error if trying to make a request without an onRequest handler", async () => {
+  it("should error if trying to make a request without an onRequest handler", async () => {
     await runDev({ main: onConnectFixture });
 
     await expect(() =>


### PR DESCRIPTION
The server we spin up makes our tests flaky. we don't have tests for dev logs anyway right now, so let's disable them.