### PR TITLE
DO NOT LAND feat: use `PartySocket` when connecting via `room.parties`

### DIFF
--- a/.changeset/early-garlics-poke.md
+++ b/.changeset/early-garlics-poke.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+feat: use `PartySocket` when connecting via `room.parties`
+
+This uses `PartySocket` when connecting why `room.parties`, whcih gives you reconnection/buffering logic without any extra effort. Non-breaking change, existing code should still just work.

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -17,6 +17,8 @@ import type {
   ExecutionContext,
 } from "@cloudflare/workers-types";
 
+import PartySocket from "partysocket";
+
 function assert(condition: unknown, msg?: string): asserts condition {
   if (!condition) {
     throw new Error(msg);
@@ -89,11 +91,11 @@ function createMultiParties(
               },
               connect: () => {
                 // wish there was a way to create a websocket from a durable object
-                return new WebSocket(
-                  key === "main"
-                    ? `ws://${options.host}/party/${name}`
-                    : `ws://${options.host}/parties/${key}/${name}`
-                );
+                return new PartySocket({
+                  host: options.host,
+                  room: name,
+                  ...(key !== "main" ? { party: key } : {}),
+                });
               },
             };
           },

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -6,6 +6,8 @@ import type {
   WebSocket,
 } from "@cloudflare/workers-types";
 
+import type PartySocket from "partysocket";
+
 // Because when you construct a `new Response()` in a user script,
 // it's assumed to be a standards-based Fetch API Response, unless overridden.
 // This is fine by us, let user return whichever response type.
@@ -30,7 +32,7 @@ export type PartyKitRoom = {
     string,
     {
       get(id: string): {
-        connect: () => WebSocket;
+        connect: () => PartySocket;
         fetch: (init: RequestInit) => Promise<PartyKitResponse>;
       };
     }


### PR DESCRIPTION
This uses `PartySocket` when connecting why `room.parties`, whcih gives you reconnection/buffering logic without any extra effort. Non-breaking change, existing code should still just work.