### PR TITLE
enable inspector in non-tests 😖

### DIFF
--- a/.changeset/clean-rats-carry.md
+++ b/.changeset/clean-rats-carry.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+enable inspector in non-tests 😖
+
+In https://github.com/partykit/partykit/pull/222, we didn't actually enble the inspector outside of tests. Oops. This fixes that.

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -157,7 +157,7 @@ export function Dev(props: DevProps) {
 function DevImpl(props: DevProps) {
   const { inspectorUrl } = useDev(props);
 
-  return props.enableInspector ? (
+  return props.enableInspector ?? true ? (
     <Inspector inspectorUrl={inspectorUrl} />
   ) : null;
 }


### PR DESCRIPTION
In https://github.com/partykit/partykit/pull/222, we didn't actually enble the inspector outside of tests. Oops. This fixes that.