### PR TITLE
fix: don't forward request to room without an `onRequest` handler

### DIFF
--- a/.changeset/tall-gorillas-learn.md
+++ b/.changeset/tall-gorillas-learn.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+fix: don't forward request to room without an `onRequest` handler

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -476,7 +476,7 @@ export default {
           if (onBeforeRequestResponse instanceof Response) {
             return onBeforeRequestResponse;
           }
-          if (!("onRequest" && Worker)) {
+          if (!("onRequest" in Worker)) {
             throw new Error("No onRequest handler");
           }
 

--- a/packages/partykit/src/tests/dev.test.tsx
+++ b/packages/partykit/src/tests/dev.test.tsx
@@ -57,9 +57,10 @@ describe("dev", () => {
   it("should error if trying to make a request without an onRequest handler", async () => {
     await runDev({ main: onConnectFixture });
 
-    await expect(() =>
-      fetch("http://localhost:1999/party/theroom")
-    ).rejects.toThrowErrorMatchingInlineSnapshot('"fetch failed"'); // TODO: we should catch the 500?
+    const res = await fetch("http://127.0.0.1:1999/party/theroom");
+
+    expect(res.status).toBe(500);
+    expect(await res.text()).toMatchInlineSnapshot('"No onRequest handler"');
   });
 
   it("should start a server for a given input script path", async () => {


### PR DESCRIPTION
yay javascript