### PR TITLE
fix: properly sort chunking in y-partykit for big values

### DIFF
--- a/.changeset/fuzzy-geese-yawn.md
+++ b/.changeset/fuzzy-geese-yawn.md
@@ -1,0 +1,7 @@
+---
+"y-partykit": patch
+---
+
+fix: properly sort chunking in y-partykit for big values
+
+So, out persistence layer has a 128kb limit on values, but `y-partykit` should/could be used for documents bigger than that. So we implemented a chunking strategy that break up values across multiple keys. When making keys for these, we didn't pad the generated indexes, which meant that for sufficiently large values, we might have assembled them back in the wrong order (because lexicographical sorting). This is a fix for that. It's a breaking change, but oddly I haven't heard from people who've faced the problem at all.

--- a/packages/y-partykit/src/storage.ts
+++ b/packages/y-partykit/src/storage.ts
@@ -92,7 +92,7 @@ export async function levelPut(
 
   const keyPrefix = keyEncoding.encode(key);
   for (let i = 0; i < chunks.length; i++) {
-    await db.put(`${keyPrefix}#${i}`, chunks[i]);
+    await db.put(`${keyPrefix}#${i.toString().padStart(3, "0")}`, chunks[i]);
   }
 }
 


### PR DESCRIPTION
So, out persistence layer has a 128kb limit on values, but `y-partykit` should/could be used for documents bigger than that. So we implemented a chunking strategy that break up values across multiple keys. When making keys for these, we didn't pad the generated indexes, which meant that for sufficiently large values, we might have assembled them back in the wrong order (because lexicographical sorting). This is a fix for that. It's a breaking change, but oddly I haven't heard from people who've faced the problem at all.