### PR TITLE
don't minify code in dev

### DIFF
--- a/.changeset/seven-turkeys-tickle.md
+++ b/.changeset/seven-turkeys-tickle.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+don't minify code in dev
+
+This a remnant from our previous arch, we don't need this anymore. (and it's getting overwritten anyway, so it's not functional)

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -25,7 +25,6 @@ const esbuildOptions: BuildOptions = {
   bundle: true,
   write: false,
   target: "esnext",
-  minify: true, // TODO: remove this once https://github.com/vercel/edge-runtime/issues/243 is fixed
 } as const;
 
 interface ReloadedEventOptions {


### PR DESCRIPTION
This a remnant from our previous arch, we don't need this anymore. (and it's getting overwritten anyway, so it's not functional)