### PR TITLE
check if crypto is defined

### DIFF
--- a/.changeset/mean-ads-rush.md
+++ b/.changeset/mean-ads-rush.md
@@ -1,0 +1,5 @@
+---
+"partysocket": patch
+---
+
+partysocket: check if crypto is defined

--- a/packages/partysocket/src/index.ts
+++ b/packages/partysocket/src/index.ts
@@ -17,7 +17,7 @@ export type PartySocketOptions = Omit<
 
 function generateUUID(): string {
   // Public Domain/MIT
-  if (crypto.randomUUID) {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
     return crypto.randomUUID();
   }
   let d = new Date().getTime(); //Timestamp


### PR DESCRIPTION
if we don't check if crypto is defined or not.
it gives the following error.

```
ReferenceError: crypto is not defined
```