### PR TITLE
delay login browser popup for 5 seconds

### DIFF
--- a/.changeset/hip-cobras-tan.md
+++ b/.changeset/hip-cobras-tan.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+delay login browser popup for 5 seconds
+
+When we're logging in, we open up a browser for a user to paste a code into github. We currently open it immediately, so users aren't sure what's happening. This PR adds a delay for a few seconds, with clearer instructions on what's happening.

--- a/packages/partykit/src/config.ts
+++ b/packages/partykit/src/config.ts
@@ -10,6 +10,7 @@ import { fetch } from "undici";
 import open from "open";
 import { version as packageVersion } from "../package.json";
 import { ConfigurationError, logger } from "./logger";
+import countdown from "./countdown";
 
 const userConfigSchema = z.object({
   login: z.string(),
@@ -100,11 +101,15 @@ export async function fetchUserConfig(): Promise<void> {
     (await res.json()) as any;
 
   console.log(
-    `Please visit ${chalk.bold(
+    `We will now open your browser to ${chalk.bold(
       verification_uri
-    )} and paste the code ${chalk.bold(user_code)}`
+    )}\nPlease paste the code ${chalk.bold(
+      user_code
+    )} (copied to your clipboard) and authorize the app.`
   );
-  console.log(`This code will expire in ${expires_in} seconds`);
+
+  await countdown("Opening browser", 5);
+
   console.log(`Waiting for you to authorize...`);
 
   // we do this because for some reason the clipboardy package doesn't work
@@ -172,6 +177,7 @@ export async function fetchUserConfig(): Promise<void> {
           2
         )
       );
+      console.log(`Logged in as ${chalk.bold(githubUserDetails.login)}`);
       return;
     }
     if (error === "authorization_pending") {

--- a/packages/partykit/src/countdown.tsx
+++ b/packages/partykit/src/countdown.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { render, Text } from "ink";
+import chalk from "chalk";
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function CountingDown({ seconds, text }: { seconds: number; text: string }) {
+  return (
+    <Text>
+      {text}: {chalk.bold(seconds)}
+    </Text>
+  );
+}
+
+export default async function countdown(text: string, seconds: number) {
+  const { unmount, rerender } = render(
+    <CountingDown seconds={seconds} text={text} />
+  );
+  for (let i = seconds; i > 0; i--) {
+    rerender(<CountingDown seconds={i} text={text} />);
+    await sleep(1000);
+  }
+  unmount();
+}


### PR DESCRIPTION
When we're logging in, we open up a browser for a user to paste a code into github. We currently open it immediately, so users aren't sure what's happening. This PR adds a delay for a few seconds, with clearer instructions on what's happening.