### PR TITLE
partysocket: warn if EventTarget is not available

### DIFF
--- a/.changeset/green-schools-deny.md
+++ b/.changeset/green-schools-deny.md
@@ -1,0 +1,5 @@
+---
+"partysocket": patch
+---
+
+partysocket: warn if EventTarget is not available

--- a/packages/partysocket/src/ws.ts
+++ b/packages/partysocket/src/ws.ts
@@ -88,6 +88,28 @@ export type ProtocolsProvider =
 
 export type Message = string | ArrayBuffer | Blob | ArrayBufferView;
 
+if (!globalThis.EventTarget) {
+  console.error(`
+  PartySocket requires a global 'EventTarget' class to be available!
+  You can use the 'event-target-shim' package to polyfill this. See https://www.npmjs.com/package/event-target-shim. 
+  First, run:
+  \`\`\`
+  npm install event-target-shim
+  \`\`\`
+  Then, add this in your code:
+  \`\`\`
+  import {Event, EventTarget} from 'event-target-shim';
+  if(!globalThis.Event) {
+    globalThis.Event = Event;
+  }
+  if(!globalThis.EventTarget) {
+    globalThis.EventTarget = EventTarget;
+  }
+  \`\`\`
+  Please file an issue at https://github.com/partykit/partykit if you're still having trouble.
+`);
+}
+
 export default class ReconnectingWebSocket extends (EventTarget as TypedEventTarget<WebSocketEventMap>) {
   private _ws: WebSocket | undefined;
   private _retryCount = -1;


### PR DESCRIPTION
Log an error if `EventTarget` isn't available when using `partysocket`, with instructions on fixing it. 