### PR TITLE
feat: define a default `process.env.PARTYKIT_HOST`

### DIFF
--- a/.changeset/breezy-carrots-dance.md
+++ b/.changeset/breezy-carrots-dance.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+feat: define a default `process.env.PARTYKIT_HOST`
+
+We can actually make a pretty good guess to what the host is for both dev and deploy, so let's define it when compiling, and remove a bunch of boilerplate in the process.

--- a/examples/basic/src/client.ts
+++ b/examples/basic/src/client.ts
@@ -1,8 +1,7 @@
 import PartySocket from "partysocket";
 
 const partySocket = new PartySocket({
-  host: "localhost:1999",
-  // host: "basic.threepointone.partykit.dev",
+  host: process.env.PARTYKIT_HOST as string,
   room: "some-room",
 });
 

--- a/examples/blocknote/package.json
+++ b/examples/blocknote/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "start": "partykit dev",
-    "deploy": "partykit deploy --define PARTYKIT_HOST=\\\"blocknote-demo.threepointone.partykit.dev\\\""
+    "deploy": "partykit deploy"
   },
   "keywords": [],
   "author": "",

--- a/examples/blocknote/src/client.tsx
+++ b/examples/blocknote/src/client.tsx
@@ -6,14 +6,9 @@ import { BlockNoteView, useBlockNote } from "@blocknote/react";
 import "@blocknote/core/style.css";
 import { getRandomUser } from "./randomUser";
 
-declare const PARTYKIT_HOST: string | undefined;
-
-const partykitHost =
-  typeof PARTYKIT_HOST === "undefined" ? "localhost:1999" : PARTYKIT_HOST;
-
 const doc = new Y.Doc();
 const provider = new YPartyKitProvider(
-  partykitHost || "localhost:1999",
+  process.env.PARTYKIT_HOST as string,
   "my-document-id",
   doc
 );

--- a/examples/lexical/package.json
+++ b/examples/lexical/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "start": "partykit dev",
-    "deploy": "partykit deploy --define PARTYKIT_HOST=\\\"lexical-demo.threepointone.partykit.dev\\\""
+    "deploy": "partykit deploy"
   },
   "keywords": [],
   "author": "",

--- a/examples/lexical/src/client.tsx
+++ b/examples/lexical/src/client.tsx
@@ -9,11 +9,6 @@ import YPartyKitProvider from "y-partykit/provider";
 
 import { createRoot } from "react-dom/client";
 
-declare const PARTYKIT_HOST: string | undefined;
-
-const partykitHost =
-  typeof PARTYKIT_HOST === "undefined" ? "localhost:1999" : PARTYKIT_HOST;
-
 function Editor() {
   const initialConfig = {
     editorState: null,
@@ -40,7 +35,7 @@ function Editor() {
           yjsDocMap.set(id, doc);
 
           const provider = new YPartyKitProvider(
-            partykitHost || "localhost:1999",
+            process.env.PARTYKIT_HOST as string,
             id,
             doc
           );

--- a/examples/monaco/src/client.tsx
+++ b/examples/monaco/src/client.tsx
@@ -30,15 +30,10 @@ window.MonacoEnvironment = {
   },
 };
 
-declare const PARTYKIT_HOST: string | undefined;
-
-const partykitHost =
-  typeof PARTYKIT_HOST === "undefined" ? "localhost:1999" : PARTYKIT_HOST;
-
 window.addEventListener("load", () => {
   const ydoc = new Y.Doc();
   const provider = new YPartyKitProvider(
-    partykitHost || "localhost:1999",
+    process.env.PARTYKIT_HOST as string,
     "monaco-demo",
     ydoc,
     {

--- a/examples/persistence/src/client.ts
+++ b/examples/persistence/src/client.ts
@@ -1,8 +1,7 @@
 import PartySocket from "partysocket";
 
 const partySocket = new PartySocket({
-  // host: "localhost:1999",
-  host: "storage-test.threepointone.partykit.dev",
+  host: process.env.PARTYKIT_HOST as string,
   room: "some-room",
 });
 

--- a/examples/wasm/src/client.ts
+++ b/examples/wasm/src/client.ts
@@ -1,8 +1,7 @@
 import PartySocket from "partysocket";
 
 const partySocket = new PartySocket({
-  host: "localhost:1999",
-  // host: "testy.threepointone.partykit.dev",
+  host: process.env.PARTYKIT_HOST as string,
   room: "some-room",
 });
 

--- a/examples/yjs/src/client.ts
+++ b/examples/yjs/src/client.ts
@@ -1,15 +1,15 @@
 import YProvider from "y-partykit/provider";
 import * as Y from "yjs";
 
-declare const PARTYKIT_HOST: string | undefined;
-
-const partykitHost =
-  typeof PARTYKIT_HOST === "undefined" ? "localhost:1999" : PARTYKIT_HOST;
-
 const doc = new Y.Doc();
-const provider = new YProvider(partykitHost, "yjs-demo", doc, {
-  connect: false,
-});
+const provider = new YProvider(
+  process.env.PARTYKIT_HOST as string,
+  "yjs-demo",
+  doc,
+  {
+    connect: false,
+  }
+);
 const yMessage: Y.Text = doc.getText("message");
 const awareness = provider.awareness;
 

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -167,6 +167,7 @@ export async function deploy(options: {
     format: assetsBuild?.format ?? "esm",
     sourcemap: assetsBuild?.sourcemap ?? true,
     define: {
+      "process.env.PARTYKIT_HOST": `"${config.name}.${user.login}.partykit.dev"`,
       ...config.define,
       ...assetsBuild?.define,
     },
@@ -286,6 +287,7 @@ export async function deploy(options: {
       ...esbuildOptions,
       minify: options.minify,
       define: {
+        "process.env.PARTYKIT_HOST": `"${config.name}.${user.login}.partykit.dev"`,
         ...esbuildOptions.define,
         ...config.define,
       },

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -243,6 +243,7 @@ function useAssetServer(
       format: assetsBuild?.format ?? "esm",
       sourcemap: assetsBuild?.sourcemap ?? true,
       define: {
+        "process.env.PARTYKIT_HOST": `"127.0.0.1:1999"`,
         ...defines,
         ...assetsBuild?.define,
       },
@@ -391,6 +392,7 @@ function useDev(options: DevProps): { inspectorUrl: string | undefined } {
         sourcemap: true,
         external: ["__STATIC_ASSETS_MANIFEST__"],
         define: {
+          "process.env.PARTYKIT_HOST": `"127.0.0.1:1999"`,
           ...esbuildOptions.define,
           ...config.define,
         },


### PR DESCRIPTION
We can actually make a pretty good guess to what the host is for both dev and deploy, so let's define it when compiling, and remove a bunch of boilerplate in the process.