### PR TITLE
Migrate to Clerk authentication behind a feature flag

### DIFF
--- a/packages/partykit/src/bin.tsx
+++ b/packages/partykit/src/bin.tsx
@@ -293,11 +293,17 @@ envCommand
 program
   .command("login")
   .description("Login to PartyKit")
-  .action(async () => {
+  .addOption(
+    new Option(
+      "-p, --provider <provider>",
+      "login provider (experimental)"
+    ).choices(["github", "partykit"])
+  )
+  .action(async ({ provider }: { provider?: "github" | "partykit" }) => {
     await printBanner();
     render(
       <Suspense>
-        <Login />
+        <Login method={provider === "partykit" ? "clerk" : provider} />
       </Suspense>
     );
   });

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -1,6 +1,6 @@
 import path from "path";
 import * as fs from "fs";
-import { fetchResult, fetchResultAsUser } from "./fetchResult";
+import { fetchResultAsUser } from "./fetchResult";
 import { File, FormData } from "undici";
 import type { BuildOptions } from "esbuild";
 import * as crypto from "crypto";

--- a/packages/partykit/src/commands/login.tsx
+++ b/packages/partykit/src/commands/login.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { getUser } from "../config";
+import { getUser, type LoginMethod } from "../config";
+
 import asyncCache from "../async-cache";
 import { Text } from "ink";
 
 const read = asyncCache();
 
-export default function Login() {
-  const userConfig = read("get-user", getUser) as Awaited<
+export default function Login({ method }: { method?: LoginMethod }) {
+  const userConfig = read("get-user", () => getUser(method)) as Awaited<
     ReturnType<typeof getUser>
   >;
 

--- a/packages/partykit/src/featureFlags.ts
+++ b/packages/partykit/src/featureFlags.ts
@@ -1,0 +1,52 @@
+import path from "path";
+import os from "os";
+import fs from "fs";
+import z from "zod";
+import JSON5 from "json5";
+import { fetchResult } from "./fetchResult";
+
+const USER_FLAGS_PATH = path.join(os.homedir(), ".partykit", "settings.json");
+
+const flagsSchema = z.object({
+  defaultLoginMethod: z.enum(["clerk", "github"]),
+  supportedLoginMethods: z.array(z.enum(["clerk", "github"])),
+});
+
+const defaultFlags: Flags = {
+  defaultLoginMethod: "github",
+  supportedLoginMethods: ["clerk", "github"],
+};
+
+let cachedFlags: Flags | undefined;
+
+type Flags = z.infer<typeof flagsSchema>;
+
+export function getFlags(): Flags {
+  if (!cachedFlags) {
+    try {
+      // use previously cached flags if available
+      cachedFlags = flagsSchema.parse(
+        JSON5.parse(fs.readFileSync(USER_FLAGS_PATH, "utf8"))
+      );
+
+      // fetch remote flags and cache them locally for offline use for next time
+      void fetchFlags().then((flags) => {
+        cachedFlags = flags;
+      });
+    } catch (e) {
+      // ignore, fall back to default settings
+    }
+  }
+
+  return {
+    ...defaultFlags,
+    ...(cachedFlags || {}),
+  };
+}
+
+async function fetchFlags(): Promise<Flags> {
+  const flags = flagsSchema.parse(await fetchResult("/flags"));
+  fs.mkdirSync(path.dirname(USER_FLAGS_PATH), { recursive: true });
+  fs.writeFileSync(USER_FLAGS_PATH, JSON.stringify(cachedFlags, null, 2));
+  return flags;
+}


### PR DESCRIPTION
Branching this out of #221 to make it easier to review.

- Implements a very simple feature flagging system.
  - Caches previously used flags on disk
  - Refreshes flags lazily on every use to avoid blocking, so new flags will only be applied on next use
  - Falls back to default flags
- Chooses login mechanism based on feature flag
  - Defaults to `github` for now, we'll change it to `clerk` on launch day
  - On launch day + `n`, we can remove `github` from supported platforms, which will force all existing clients to migrate
- Adds a `--provider` argument to `partykit login` for early testing (to be removed once stable)