### PR TITLE
fix: type signatures on `onBeforeRequest`/`onBeforeConnect`

### DIFF
--- a/.changeset/hot-rice-fail.md
+++ b/.changeset/hot-rice-fail.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+fix: type signatures on `onBeforeRequest`/`onBeforeConnect`
+
+The types on `onBeforeRequest`/`onBeforeConnect` were causing errors, this should fix 'em

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -75,9 +75,8 @@ type RequestHandler = {
     ctx: ExecutionContext
   ) =>
     | UserDefinedRequest
-    | Promise<UserDefinedRequest>
     | UserDefinedResponse
-    | Promise<UserDefinedResponse>;
+    | Promise<UserDefinedRequest | UserDefinedResponse>;
   onRequest?: (
     req: Request,
     room: PartyKitRoom
@@ -107,9 +106,8 @@ type ConnectionHandler = RequestHandler & {
     ctx: ExecutionContext
   ) =>
     | UserDefinedRequest
-    | Promise<UserDefinedRequest>
     | UserDefinedResponse
-    | Promise<UserDefinedResponse>;
+    | Promise<UserDefinedRequest | UserDefinedResponse>;
   /**
    * PartyKitServer may opt into being hibernated between WebSocket
    * messages, which enables a single server to handle more connections.


### PR DESCRIPTION
The types on `onBeforeRequest`/`onBeforeConnect` were causing errors, this should fix 'em