### PR TITLE
fix: serve newer assets on changes

### DIFF
--- a/.changeset/breezy-bananas-clean.md
+++ b/.changeset/breezy-bananas-clean.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+fix: serve newer assets on changes
+
+We had a bug where newly created assets weren't being served on dev, this should fix that.


### PR DESCRIPTION
We had a bug where newly created assets weren't being served on dev, this should fix that.