### PR TITLE
don't compile node builtins that the platform supports

### DIFF
--- a/.changeset/funny-islands-help.md
+++ b/.changeset/funny-islands-help.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+don't compile node builtins that the platform supports
+
+We support some node builtins, so we shouldn't try to compile them into the bundle.

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -39,6 +39,7 @@ import { ConfigurationError, logger } from "./logger";
 import type { StaticAssetsManifestType } from "./server";
 import { findUpSync } from "find-up";
 import { fileURLToPath } from "url";
+import nodejsCompatPlugin from "./nodejs-compat";
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -547,6 +548,7 @@ export const ${name} = ${name}Party;
         ...config.define,
       },
       plugins: [
+        nodejsCompatPlugin,
         {
           name: "partykit-wasm-publish",
           setup(build) {

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -23,6 +23,7 @@ import getPort from "get-port";
 import asyncCache from "./async-cache";
 import open from "open";
 import type { StaticAssetsManifestType } from "./server";
+import nodejsCompatPlugin from "./nodejs-compat";
 
 const esbuildOptions: BuildOptions = {
   format: "esm",
@@ -539,6 +540,7 @@ Workers["${name}"] = ${name};
           ...config.define,
         },
         plugins: [
+          nodejsCompatPlugin,
           {
             name: "partykit",
             setup(build) {

--- a/packages/partykit/src/nodejs-compat.ts
+++ b/packages/partykit/src/nodejs-compat.ts
@@ -1,0 +1,41 @@
+import type { Plugin } from "esbuild";
+
+// via https://developers.cloudflare.com/workers/runtime-apis/nodejs/
+const supportedNodeBuiltins = [
+  "assert",
+  "async_hooks",
+  "buffer",
+  "diagnostics_channel",
+  "events",
+  "path",
+  "process",
+  "stream",
+  "string_decoder",
+  "util",
+];
+
+const plugin: Plugin = {
+  name: "nodejs-compat",
+  setup(build) {
+    build.onResolve({ filter: /^node:/ }, (args) => {
+      const name = args.path.replace(/^node:/, "");
+      if (supportedNodeBuiltins.includes(name)) {
+        return { path: args.path, external: true };
+      } else {
+        throw new Error(`Unsupported node builtin: ${name}`);
+      }
+    });
+    build.onResolve(
+      { filter: new RegExp(`^(${supportedNodeBuiltins.join("|")})$`) },
+      async (args) => {
+        // TODO: we want to use import.meta.resolve here
+        // but it's too early to use, and my experiments with
+        // it always log node:process (instead of any existing package)
+        // So let's land this and revisit if folks want differently
+        return { path: `node:${args.path}`, external: true };
+      }
+    );
+  },
+};
+
+export default plugin;


### PR DESCRIPTION
We support some node builtins, so we shouldn't try to compile them into the bundle.

