### PR TITLE
create: always make a package.json

### DIFF
--- a/.changeset/mean-buckets-hear.md
+++ b/.changeset/mean-buckets-hear.md
@@ -1,0 +1,7 @@
+---
+"create-partykit": patch
+---
+
+create: always make a package.json
+
+we were trying got be clever and not make a package.json if there was a parent (that's wasn't a monorepo root). Turns out folks have package.json's all the time. So this just always makes a package.json, and only runs the installer in the root package,json dir f it's a monorepo/has workspaces

--- a/packages/create-partykit/README.md
+++ b/packages/create-partykit/README.md
@@ -10,7 +10,7 @@ Scaffolding for PartyKit projects.
 npm create partykit@latest
 ```
 
-`create-partykit` automatically runs in interactive mode, but you can also specify your project name and other options with command line arguments.
+`create-partykit` automatically runs in interactive mode, but you can specify your project name and other options with command line arguments.
 
 ### CLI Flags
 


### PR DESCRIPTION
we were trying got be clever and not make a package.json if there was a parent (that's wasn't a monorepo root). Turns out folks have package.json's all the time. So this just always makes a package.json, and only runs the installer in the root package,json dir f it's a monorepo/has workspaces