### PR TITLE
create: don't initialise git repo inside another

### DIFF
--- a/.changeset/thin-scissors-guess.md
+++ b/.changeset/thin-scissors-guess.md
@@ -1,0 +1,13 @@
+---
+"create-partykit": patch
+"partykit": patch
+---
+
+create: don't initialise git repo inside another
+
+When we create a project, we shouldn't try to create a git repo if we're initialising inside another git repo (like a monorepo). This PR detects whether there's a git folder and skips the git repo creation part.
+
+Additionally:
+
+- we switch away from `find-config` to `find-up` everywhere, since it works on both files and directories
+- I also took the opportunity to enable `verbatimModuleSyntax` in our tsconfig, which makes vscode import types correctly when we auto-import

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,16 +83,6 @@
       "version": "0.0.0",
       "license": "ISC"
     },
-    "examples/something": {
-      "version": "0.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "partysocket": "0.0.0"
-      },
-      "devDependencies": {
-        "partykit": "0.0.0"
-      }
-    },
     "examples/wasm": {
       "name": "@partykit/examples-wasm",
       "version": "0.0.0",
@@ -3249,12 +3239,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
       "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
-    },
-    "node_modules/@types/find-config": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/find-config/-/find-config-1.0.1.tgz",
-      "integrity": "sha512-H4DFIQMwxCKRgVWMSqALg6aowTOgZi5D4pSPBBuOQFJLRwfNZaByhC9+s870CZgTRJoyVg5J+iesdF5uvnJ0mA==",
-      "dev": true
     },
     "node_modules/@types/gradient-string": {
       "version": "1.1.2",
@@ -6605,17 +6589,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/find-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-config/-/find-config-1.0.0.tgz",
-      "integrity": "sha512-Z+suHH+7LSE40WfUeZPIxSxypCWvrzdVc60xAjUShZeT5eMWM0/FQUduq3HjluyfAHWvC/aOBkT1pTZktyF/jg==",
-      "dependencies": {
-        "user-home": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/find-root": {
@@ -10319,14 +10292,6 @@
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="
     },
-    "node_modules/os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -13759,17 +13724,6 @@
         }
       }
     },
-    "node_modules/user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
-      "dependencies": {
-        "os-homedir": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -14541,7 +14495,7 @@
         "chalk": "^5.3.0",
         "commander": "^11.0.0",
         "execa": "^7.2.0",
-        "find-config": "^1.0.0",
+        "find-up": "^6.3.0",
         "gradient-string": "^2.0.2",
         "ink": "^4.3.1",
         "ink-select-input": "^5.0.0",
@@ -14951,6 +14905,71 @@
         "@esbuild/win32-x64": "0.19.2"
       }
     },
+    "packages/create-partykit/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-partykit/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-partykit/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-partykit/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-partykit/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "packages/partykit": {
       "version": "0.0.1",
       "dependencies": {
@@ -14963,7 +14982,7 @@
         "dotenv": "^16.3.1",
         "esbuild": "^0.19.2",
         "execa": "^7.2.0",
-        "find-config": "^1.0.0",
+        "find-up": "^6.3.0",
         "get-port": "^7.0.0",
         "gradient-string": "^2.0.2",
         "http-terminator": "^3.2.0",
@@ -14988,7 +15007,6 @@
       },
       "devDependencies": {
         "@types/execa": "^2.0.0",
-        "@types/find-config": "^1.0.1",
         "@types/gradient-string": "^1.1.2",
         "@types/mime": "^3.0.1",
         "@types/node": "^20.5.0",
@@ -15387,6 +15405,71 @@
         "@esbuild/win32-arm64": "0.19.2",
         "@esbuild/win32-ia32": "0.19.2",
         "@esbuild/win32-x64": "0.19.2"
+      }
+    },
+    "packages/partykit/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/partykit/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/partykit/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/partykit/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/partykit/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "packages/partykit/node_modules/signal-exit": {

--- a/packages/create-partykit/js-template/tsconfig.json
+++ b/packages/create-partykit/js-template/tsconfig.json
@@ -75,7 +75,7 @@
 
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    "verbatimModuleSyntax": true /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */,
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */

--- a/packages/create-partykit/package.json
+++ b/packages/create-partykit/package.json
@@ -20,7 +20,7 @@
     "chalk": "^5.3.0",
     "commander": "^11.0.0",
     "execa": "^7.2.0",
-    "find-config": "^1.0.0",
+    "find-up": "^6.3.0",
     "gradient-string": "^2.0.2",
     "ink": "^4.3.1",
     "ink-select-input": "^5.0.0",

--- a/packages/create-partykit/ts-template/tsconfig.json
+++ b/packages/create-partykit/ts-template/tsconfig.json
@@ -75,7 +75,7 @@
 
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    "verbatimModuleSyntax": true /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */,
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */

--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -21,7 +21,7 @@
     "dotenv": "^16.3.1",
     "esbuild": "^0.19.2",
     "execa": "^7.2.0",
-    "find-config": "^1.0.0",
+    "find-up": "^6.3.0",
     "get-port": "^7.0.0",
     "gradient-string": "^2.0.2",
     "http-terminator": "^3.2.0",
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "@types/execa": "^2.0.0",
-    "@types/find-config": "^1.0.1",
     "@types/gradient-string": "^1.1.2",
     "@types/mime": "^3.0.1",
     "@types/node": "^20.5.0",

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -13,7 +13,8 @@ import InkTable from "./ink-table";
 import { Dev } from "./dev";
 import type { DevProps } from "./dev";
 
-export { Dev, DevProps };
+export { Dev };
+export type { DevProps };
 
 import { execaCommand } from "execa";
 import { version as packageVersion } from "../package.json";

--- a/packages/partykit/src/config.ts
+++ b/packages/partykit/src/config.ts
@@ -4,7 +4,7 @@ import path from "path";
 import * as dotenv from "dotenv";
 import { z } from "zod";
 import JSON5 from "json5";
-import findConfig from "find-config";
+import { findUpSync } from "find-up";
 import { ConfigurationError, logger } from "./logger";
 import chalk from "chalk";
 import { getFlags } from "./featureFlags";
@@ -184,9 +184,9 @@ export type ConfigOverrides = Config; // Partial? what of .env?
 
 export function getConfigPath() {
   return (
-    findConfig("partykit.json", { home: false }) ||
-    findConfig("partykit.json5", { home: false }) ||
-    findConfig("partykit.jsonc", { home: false })
+    findUpSync("partykit.json") ||
+    findUpSync("partykit.json5") ||
+    findUpSync("partykit.jsonc")
   );
 }
 
@@ -203,8 +203,8 @@ export function getConfig(
   overrides: ConfigOverrides = {},
   options?: { readEnvLocal?: boolean }
 ): Config {
-  const envPath = findConfig(".env");
-  const envLocalPath = findConfig(".env.local");
+  const envPath = findUpSync(".env");
+  const envLocalPath = findUpSync(".env.local");
   let envVars: Record<string, string> = {};
   if (envPath) {
     console.log(
@@ -239,7 +239,7 @@ export function getConfig(
     }
 
     let packageJsonConfig = {} as ConfigOverrides;
-    const packageJsonPath = findConfig("package.json", { home: false });
+    const packageJsonPath = findUpSync("package.json");
     if (packageJsonPath) {
       packageJsonConfig =
         JSON.parse(fs.readFileSync(packageJsonPath, "utf8")).partykit || {};

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -74,6 +74,7 @@
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    "verbatimModuleSyntax": true,
 
     /* Type Checking */
     "strict": true /* Enable all strict type-checking options. */,


### PR DESCRIPTION
When we create a project, we shouldn't try to create a git repo if we're initialising inside another git repo (like a monorepo). This PR detects whether there's a git folder and skips the git repo creation part.

Additionally:
- we switch away from `find-config` to `find-up` everywhere, since it works on both files and directories
- I also took the opportunity to enable `verbatimModuleSyntax` in our tsconfig, which makes vscode import types correctly when we auto-import