### PR TITLE
Separate modes for local dev against local dev vs production

### DIFF
--- a/.changeset/rare-eagles-share.md
+++ b/.changeset/rare-eagles-share.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Separate modes for local dev against local dev vs production

--- a/package-lock.json
+++ b/package-lock.json
@@ -5892,6 +5892,42 @@
         "node": ">=10"
       }
     },
+    "node_modules/dotenv-cli": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-7.3.0.tgz",
+      "integrity": "sha512-314CA4TyK34YEJ6ntBf80eUY+t1XaFLyem1k9P0sX1gn30qThZ5qZr/ZwE318gEnzyYP9yj9HJk6SqwE0upkfw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "dotenv": "^16.3.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-cli/node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/duplexer3": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
@@ -14998,6 +15034,7 @@
         "@types/update-notifier": "^6.0.4",
         "@types/ws": "^8.5.5",
         "devtools-protocol": "^0.0.1182435",
+        "dotenv-cli": "^7.3.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "zod-to-json-schema": "^3.21.4"
       }

--- a/packages/partykit/.env.development
+++ b/packages/partykit/.env.development
@@ -1,0 +1,5 @@
+# Do not store secrets here, the .env files are committed to source control!
+PARTYKIT_API_BASE=http://127.0.0.1:8787
+PARTYKIT_DASHBOARD_BASE=http://localhost:3000 
+CLERK_PUBLISHABLE_KEY=pk_test_b2JsaWdpbmctc25pcGUtMzcuY2xlcmsuYWNjb3VudHMuZGV2JA
+

--- a/packages/partykit/.env.production
+++ b/packages/partykit/.env.production
@@ -1,0 +1,4 @@
+# Do not store secrets here, the .env files are committed to source control!
+PARTYKIT_API_BASE=https://api.partykit.dev 
+PARTYKIT_DASHBOARD_BASE=https://dashboard.partykit.io 
+CLERK_PUBLISHABLE_KEY=pk_live_Y2xlcmsucGFydHlraXQuaW8k

--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -53,6 +53,7 @@
     "@types/update-notifier": "^6.0.4",
     "@types/ws": "^8.5.5",
     "devtools-protocol": "^0.0.1182435",
+    "dotenv-cli": "^7.3.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "zod-to-json-schema": "^3.21.4"
   },
@@ -65,7 +66,9 @@
   ],
   "scripts": {
     "clean": "shx rm -rf dist dts *.d.ts *.d.ts.map && mkdir dts",
-    "start": "npm run clean && concurrently \"cross-env PARTYKIT_API_BASE=http://127.0.0.1:8787 PARTYKIT_DASHBOARD_BASE=http://localhost:3000 node -r esbuild-register --watch --watch-path src --watch-path facade scripts/build.ts\" \"tsc -p scripts/tsconfig.extract.json --watch\" \"node -r esbuild-register --watch --watch-path dts scripts/copy-dts.ts\" --kill-others",
-    "build": "npm run clean && cross-env PARTYKIT_API_BASE=https://api.partykit.dev PARTYKIT_DASHBOARD_BASE=https://dashboard.partykit.io node -r esbuild-register scripts/build.ts --production && tsc -p scripts/tsconfig.extract.json --incremental false && node -r esbuild-register scripts/copy-dts.ts"
+    "dev:local": "npm run clean && concurrently \"dotenv -c development node -- -r esbuild-register --watch --watch-path src --watch-path facade scripts/build.ts\" \"tsc -p scripts/tsconfig.extract.json --watch\" \"node -r esbuild-register --watch --watch-path dts scripts/copy-dts.ts\" --kill-others",
+    "dev:remote": "npm run clean && concurrently \"dotenv -c production node -- -r esbuild-register --watch --watch-path src --watch-path facade scripts/build.ts\" \"tsc -p scripts/tsconfig.extract.json --watch\" \"node -r esbuild-register --watch --watch-path dts scripts/copy-dts.ts\" --kill-others",
+    "start": "npm run dev:local",
+    "build": "npm run clean && dotenv -c production node -- -r esbuild-register scripts/build.ts --production && tsc -p scripts/tsconfig.extract.json --incremental false && node -r esbuild-register scripts/copy-dts.ts"
   }
 }

--- a/packages/partykit/scripts/build.ts
+++ b/packages/partykit/scripts/build.ts
@@ -40,6 +40,7 @@ esbuild.buildSync({
     PARTYKIT_API_BASE: `"${process.env.PARTYKIT_API_BASE}"`,
     "process.env.NODE_ENV": `"${isProd ? "production" : "development"}"`,
     PARTYKIT_DASHBOARD_BASE: `"${process.env.PARTYKIT_DASHBOARD_BASE}"`,
+    CLERK_PUBLISHABLE_KEY: `"${process.env.CLERK_PUBLISHABLE_KEY}"`,
   },
 });
 

--- a/packages/partykit/src/auth/clerk.ts
+++ b/packages/partykit/src/auth/clerk.ts
@@ -1,6 +1,14 @@
 import type Clerk from "@clerk/clerk-js";
 import clerk from "@clerk/clerk-js/headless/index.js";
 
+declare const CLERK_PUBLISHABLE_KEY: string | undefined;
+const PUBLISHABLE_KEY =
+  process.env.CLERK_PUBLISHABLE_KEY || CLERK_PUBLISHABLE_KEY;
+
+if (!PUBLISHABLE_KEY) {
+  throw new Error("CLERK_PUBLISHABLE_KEY not defined");
+}
+
 const ClerkConstructor = clerk.default;
 
 global.window = global.window || {};
@@ -8,8 +16,6 @@ global.window = global.window || {};
 type TokenStore = {
   token?: string;
 };
-
-const CLERK_PUBLISHABLE_KEY = "pk_live_Y2xlcmsucGFydHlraXQuaW8k";
 
 const clerkFactory = ({ publishableKey }: { publishableKey: string }) => {
   /**
@@ -43,7 +49,7 @@ const clerkFactory = ({ publishableKey }: { publishableKey: string }) => {
 };
 
 export const createClerkClient = clerkFactory({
-  publishableKey: CLERK_PUBLISHABLE_KEY,
+  publishableKey: PUBLISHABLE_KEY,
 });
 
 export const fetchClerkClientToken = async (signInToken: string) => {

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -2,3 +2,5 @@
 globalThis.PARTYKIT_API_BASE = "fuck.partykit.dev";
 // eslint-disable-next-line no-undef
 globalThis.PARTYKIT_DASHBOARD_BASE = "dashboard.partykit.io";
+// eslint-disable-next-line no-undef
+globalThis.CLERK_PUBLISHABLE_KEY = "do_not_access_clerk_in_tests";


### PR DESCRIPTION
We need to connect to the dev clerk instance when doing local development against locally running dashboard.
- `npm start` -- runs against local `partyworker`, `partycentral` and development Clerk instance
- `npm run dev:remote` -- runs against production instances (useful for dev/debugging without setting up local dev for everything else).

Uses `dotenv` instead of `cross-env` to reduce config duplication in package.json.