### PR TITLE
feat: add hot keys to open a browser, clear console, exit

### DIFF
--- a/.changeset/purple-rivers-learn.md
+++ b/.changeset/purple-rivers-learn.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+feat: add hot keys to open a browser, clear console, exit
+
+Stealing this idea from wrangler: this adds a floating bar with hotkeys to open a browser, clear the console, or simply exit the process.


### PR DESCRIPTION
Stealing this idea from wrangler: this adds a floating bar with hotkeys to open a browser, clear the console, or simply exit the process. We'll add an inspector button later!