### PR TITLE
Generate session tokens for CI

### DIFF
--- a/.changeset/angry-olives-fold.md
+++ b/.changeset/angry-olives-fold.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Add `partykit token generate` to create API tokens

--- a/packages/partykit/src/auth/clerk.ts
+++ b/packages/partykit/src/auth/clerk.ts
@@ -104,6 +104,5 @@ export const expireClerkClientToken = async (
   };
 
   const clerk = await createClerkClient({ tokenStore, headers });
-
   await clerk.signOut();
 };

--- a/packages/partykit/src/auth/device.ts
+++ b/packages/partykit/src/auth/device.ts
@@ -12,7 +12,7 @@ if (!DASHBOARD_BASE) {
   throw new Error("PARTYKIT_DASHBOARD_BASE not defined");
 }
 
-export async function signInWithBrowser(): Promise<
+export async function signInWithBrowser(mode: "cli" | "token"): Promise<
   | {
       token: string;
       teamId: string;
@@ -88,7 +88,7 @@ export async function signInWithBrowser(): Promise<
     const redirectUrl = `http://localhost:${port}/device/callback`;
 
     // the remote server url that will handle the login flow
-    const loginUrl = `${DASHBOARD_BASE}/login/device?redirectUrl=${encodeURIComponent(
+    const loginUrl = `${DASHBOARD_BASE}/login/device?mode=${mode}&redirectUrl=${encodeURIComponent(
       redirectUrl
     )}`;
 

--- a/packages/partykit/src/bin.tsx
+++ b/packages/partykit/src/bin.tsx
@@ -329,6 +329,22 @@ program
     await cli.whoami();
   });
 
+const tokenCommand = program
+  .command("token")
+  .description("Manage authentication tokens")
+  .action(async () => {
+    await printBanner();
+    tokenCommand.outputHelp();
+  });
+
+tokenCommand
+  .command("generate")
+  .description("Generate a secret authentication token")
+  .action(async () => {
+    await printBanner();
+    await cli.generateToken();
+  });
+
 // semiver implementation via https://github.com/lukeed/semiver/blob/ae7eebe6053c96be63032b14fb0b68e2553fcac4/src/index.js
 
 /**

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -19,7 +19,13 @@ export type { DevProps };
 import { execaCommand } from "execa";
 import { version as packageVersion } from "../package.json";
 
-import { getConfig, getConfigPath, getUser, getUserConfig } from "./config";
+import {
+  createClerkServiceTokenSession,
+  getConfig,
+  getConfigPath,
+  getUser,
+  getUserConfig,
+} from "./config";
 import type { TailFilterMessage } from "./tail/filters";
 import { translateCLICommandToFilterMessage } from "./tail/filters";
 import { jsonPrintLogs, prettyPrintLogs } from "./tail/printing";
@@ -579,6 +585,23 @@ export async function list(options: { format: "json" | "pretty" }) {
   } else {
     render(<InkTable data={res} />);
   }
+}
+
+export async function generateToken() {
+  logger.log("Opening web browser to authenticate you...");
+  logger.log("");
+  const session = await createClerkServiceTokenSession();
+
+  // Using console directly instead of ink because ink inserts line breaks
+  // into text and makes it harder to copy the generated token
+  logger.log(
+    "Set the following environment variables to allow a machine to deploy to PartyKit on your behalf:"
+  );
+  logger.log("");
+  logger.log(`PARTYKIT_LOGIN=${chalk.bold(session.login)}`);
+  logger.log(`PARTYKIT_TOKEN=${chalk.bold(session.access_token)}`);
+  logger.log("");
+  logger.log("Store the token securely, it will not be shown again.");
 }
 
 export async function whoami() {

--- a/packages/partykit/src/config.ts
+++ b/packages/partykit/src/config.ts
@@ -209,7 +209,11 @@ export async function logout() {
   if (config) {
     fs.rmSync(USER_CONFIG_PATH);
     if (config.type === "clerk") {
-      await expireClerkClientToken(config.access_token);
+      try {
+        await expireClerkClientToken(config.access_token);
+      } catch (e) {
+        logger.info(chalk.dim("You were logged out this device."));
+      }
     }
   }
   // TODO: delete the token from github


### PR DESCRIPTION
Adds a new `npx partykit token generate` command that allows you to generate a new Clerk client session.

From code perspective, this is ready to land, but since it relies on the yet-unpublicised dashboard, it may make sense to only ship this when we're ready to onboard users there.

While developing this, I made a few other improvements to the session management worflow:
- Sessions are now tagged with custom user agents, so the user can differentiate between CLI sessions and (CI) token sessions in the Clerk account management page
- Sessions are expired upon logout (because our device session length is very long, these will otherwise pile up)
