### PR TITLE
add new lines when hitting return in `dev`

### DIFF
--- a/.changeset/happy-needles-call.md
+++ b/.changeset/happy-needles-call.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+add new lines when hitting return in `dev`
+
+fairly common behaviour with other CLIs, just adding it to ours as well.

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -173,7 +173,11 @@ function useHotkeys(props: {
   // const [toggles, setToggles] = useState({});
   const { exit } = useApp();
 
-  useInput(async (input, _key) => {
+  useInput(async (input, key) => {
+    if (key.return) {
+      console.log("");
+      return;
+    }
     switch (input.toLowerCase()) {
       // clear console
       case "c":


### PR DESCRIPTION
fairly common behaviour with other CLIs, just adding it to ours as well.