### PR TITLE
remove `./` from `create-partykit` path placeholder

### DIFF
--- a/packages/create-partykit/src/index.tsx
+++ b/packages/create-partykit/src/index.tsx
@@ -194,7 +194,7 @@ export async function init(options: {
           <Text>Where should we create your project?</Text>
           <TextInput
             value={text}
-            placeholder={` ./${randomName}`}
+            placeholder={`${randomName}`}
             onChange={setText}
             onSubmit={done}
           />


### PR DESCRIPTION
Tiniest of nits, but I stubbed my toe here when running `npm create partykit` because the placeholder shows a path with `./` but entering a path starting with `./` will throw an error. If you actually do want to accept `./`, feel free to take this as a bug report and close the PR.

![CleanShot 2023-08-31 at 20 58 31@2x](https://github.com/partykit/partykit/assets/32459922/23579958-ffa9-4e34-a4a0-6a7330817335)


![CleanShot 2023-08-31 at 20 57 38@2x](https://github.com/partykit/partykit/assets/32459922/d2b74062-287d-489c-8719-18142c87a7f8)