### PR TITLE
y-partykit/react: a hook version of the provider

### DIFF
--- a/.changeset/long-ways-swim.md
+++ b/.changeset/long-ways-swim.md
@@ -1,0 +1,5 @@
+---
+"y-partykit": patch
+---
+
+`tsximport useYProvider from "y-partykit/react";function App() {  const provider = useYProvider({    host: "localhost:1999",    room: "my-document-name",    doc: yDoc, // optional!    options,  });}`

--- a/README.md
+++ b/README.md
@@ -217,6 +217,20 @@ const provider = new YPartyKitProvider(
 );
 ```
 
+If you're using react, then you can the hook version of the provider: `useYPartyKitProvider`.
+
+```tsx
+import useYProvider from "y-partykit/react";
+function App() {
+  const provider = useYProvider({
+    host: "localhost:1999",
+    room: "my-document-name",
+    doc: yDoc, // optional!
+    options,
+  });
+}
+```
+
 Refer to the [official Yjs documentation](https://docs.yjs.dev/ecosystem/editor-bindings) for more information. Examples provided in the Yjs documentation should work seamlessly with `y-partykit` (ensure to replace `y-websocket` with `y-partykit/provider`).
 
 ## Contributing

--- a/packages/y-partykit/README.md
+++ b/packages/y-partykit/README.md
@@ -87,4 +87,18 @@ const provider = new YPartyKitProvider(
 );
 ```
 
+If you're using react, then you can the hook version of the provider: `useYPartyKitProvider`.
+
+```tsx
+import useYProvider from "y-partykit/react";
+function App() {
+  const provider = useYProvider({
+    host: "localhost:1999",
+    room: "my-document-name",
+    doc: yDoc, // optional!
+    options,
+  });
+}
+```
+
 Refer to the [official Yjs documentation](https://docs.yjs.dev/ecosystem/editor-bindings) for more information. Examples provided in the Yjs documentation should work seamlessly with `y-partykit` (ensure to replace `y-websocket` with `y-partykit/provider`).

--- a/packages/y-partykit/package.json
+++ b/packages/y-partykit/package.json
@@ -19,13 +19,19 @@
       "types": "./storage.d.ts",
       "import": "./dist/storage.mjs",
       "require": "./dist/storage.js"
+    },
+    "./react": {
+      "types": "./react.d.ts",
+      "import": "./dist/react.mjs",
+      "require": "./dist/react.js"
     }
   },
   "tsup": {
     "entry": [
       "src/index.ts",
       "src/storage.ts",
-      "src/provider.ts"
+      "src/provider.ts",
+      "src/react.ts"
     ],
     "format": [
       "esm",
@@ -52,6 +58,7 @@
   "dependencies": {
     "lib0": "^0.2.60",
     "lodash.debounce": "^4.0.8",
+    "react": "^18.2.0",
     "y-protocols": "^1.0.5",
     "yjs": "^13.5.44"
   }

--- a/packages/y-partykit/src/provider.ts
+++ b/packages/y-partykit/src/provider.ts
@@ -1,4 +1,4 @@
-import type * as Y from "yjs";
+import { Doc as YDoc } from "yjs";
 import * as bc from "lib0/broadcastchannel";
 import * as time from "lib0/time";
 import * as encoding from "lib0/encoding";
@@ -265,7 +265,7 @@ export class WebsocketProvider extends Observable<string> {
   bcChannel: string;
   url: string;
   roomname: string;
-  doc: Y.Doc;
+  doc: YDoc;
   _WS: typeof WebSocket;
   awareness: awarenessProtocol.Awareness;
   wsconnected: boolean;
@@ -288,7 +288,7 @@ export class WebsocketProvider extends Observable<string> {
   constructor(
     serverUrl: string,
     roomname: string,
-    doc: Y.Doc,
+    doc: YDoc,
     {
       connect = true,
       awareness = new awarenessProtocol.Awareness(doc),
@@ -556,7 +556,7 @@ export default class YPartyKitProvider extends WebsocketProvider {
   constructor(
     host: string,
     room: string,
-    doc: Y.Doc,
+    doc?: YDoc,
     options: ConstructorParameters<typeof WebsocketProvider>[3] & {
       party?: string;
     } = {}
@@ -577,7 +577,7 @@ export default class YPartyKitProvider extends WebsocketProvider {
     } else {
       options.params._pk = id;
     }
-    super(serverUrl, room, doc, options);
+    super(serverUrl, room, doc ?? new YDoc(), options);
     this.id = id;
   }
 }

--- a/packages/y-partykit/src/react.ts
+++ b/packages/y-partykit/src/react.ts
@@ -1,0 +1,31 @@
+import type * as Y from "yjs";
+import YPartyKitProvider from "./provider";
+import { useState, useEffect } from "react";
+
+type UseYPartyKitProviderOptions = {
+  host: string;
+  room: string;
+  party?: string;
+  doc?: Y.Doc;
+  options: ConstructorParameters<typeof YPartyKitProvider>[3];
+};
+
+export default function useYProvider(
+  yProviderOptions: UseYPartyKitProviderOptions
+) {
+  const { host, room, party, doc, options } = yProviderOptions;
+  const [provider] = useState<YPartyKitProvider>(
+    () =>
+      new YPartyKitProvider(host, room, doc, {
+        connect: false,
+        party,
+        ...options,
+      })
+  );
+
+  useEffect(() => {
+    provider.connect();
+    return () => provider.disconnect();
+  }, [provider]);
+  return provider;
+}


### PR DESCRIPTION
This adds a react hook version of the YPartyKitProvider.

```tsx
import useYProvider from "y-partykit/react";
function App() {
  const provider = useYProvider({
    host: "localhost:1999",
    room: "my-document-name",
    doc: yDoc, // optional!
    options,
  });
}
```