### PR TITLE
change naming of /server exports

### DIFF
--- a/.changeset/lovely-tigers-marry.md
+++ b/.changeset/lovely-tigers-marry.md
@@ -1,0 +1,11 @@
+---
+"partykit": patch
+"@partykit/blog": patch
+"@partykit/docs": patch
+---
+
+change naming of /server exports
+
+This changes the naming of our exported types from `partykit/server`. The motivation here was aesthetic/simplification. Most of the exports los the `Party` prefix; i.e. `PartyServer` becomes `Server`, `PartyConnection` becomes `Connection`, and so on. If you look at the class example, this doesn't drastically change the code; the import becomes a lot shorter (`import type * as Party from 'partykit/server'` gets all the required types) and required types are taken by `Party.*`.
+
+I also did a run on all the docs/templates and the blog post, but lemme know if I missed anything!

--- a/apps/docs/src/content/docs/guides/authentication.md
+++ b/apps/docs/src/content/docs/guides/authentication.md
@@ -8,6 +8,7 @@ When your PartyKit project is deployed, the server accepts HTTP requests and Web
 In order to prevent unauthorized requests being routed to your server, you can implement authentication in your `onBeforeConnect` and `onBeforeRequest` handlers.
 
 <!-- TODO: Better image design -->
+
 ![onBefore handlers](../../../assets/on-before.png)
 
 :::note[About the example code]
@@ -29,21 +30,21 @@ const partySocket = new PartySocket({
   room: "room-id",
   // pass the token to PartyKit in the query string
   query: {
-    token
-  }
+    token,
+  },
 });
 ```
 
 You can then verify your user's identity in a `static onBeforeConnect` method:
 
 ```ts
-import type { PartyRequest, PartyServer } from "partykit/server";
+import * as Party from "partykit/server";
 import { verifyToken } from "@clerk/backend";
 
 const CLERK_ENDPOINT = "https://clerk.yourdomain.com";
 
-export default class Server implements PartyServer {
-  static async onBeforeConnect(request: PartyRequest) {
+export default class Server implements Party.Server {
+  static async onBeforeConnect(request: Party.Request) {
     try {
       // get token from request query string
       const token = new URL(request.url).searchParams.get("token") ?? "";
@@ -58,7 +59,7 @@ export default class Server implements PartyServer {
     }
   }
 
-  onRequest(req: PartyRequest) {
+  onRequest(req: Party.Request) {
     return new Response(`Hello from party!`);
   }
 }
@@ -67,31 +68,32 @@ export default class Server implements PartyServer {
 ### Authenticating HTTP requests
 
 <!-- TODO: Add links to guide/API-->
+
 You can configure your PartyKit server to [respond to HTTP requests](/guides/responding-to-http-requests).
 
 To ensure that only authorized users can make requests to your server, you should send a session token in the request.
 
- The recommended way is to pass it as an `Authorization` header:
+The recommended way is to pass it as an `Authorization` header:
 
 ```ts
 fetch(`${PARTYKIT_HOST}/party/${roomId}`, {
   headers: {
     // get an auth token using your authentication client library
-    Authorization: getToken()
-  }
-})
+    Authorization: getToken(),
+  },
+});
 ```
 
 You can then verify your user's identity in a `static onBeforeRequest` method:
 
 ```ts
-import type { PartyRequest, PartyServer } from "partykit/server";
+import type * as Party from "partykit/server";
 import { verifyToken } from "@clerk/backend";
 
 const CLERK_ENDPOINT = "https://clerk.yourdomain.com";
 
-export default class Server implements PartyServer {
-  static async onBeforeRequest(request: PartyRequest) {
+export default class Server implements Party.Server {
+  static async onBeforeRequest(request: Party.Request) {
     try {
       // get token from request headers
       const token = request.headers.get("Authorization") ?? "";
@@ -106,7 +108,7 @@ export default class Server implements PartyServer {
     }
   }
 
-  onRequest(req: PartyRequest) {
+  onRequest(req: Party.Request) {
     return new Response(`Hello from party!`);
   }
 }

--- a/apps/docs/src/content/docs/guides/responding-to-http-requests.md
+++ b/apps/docs/src/content/docs/guides/responding-to-http-requests.md
@@ -12,27 +12,26 @@ Parties accept requests at `/parties/:party/:room-id`. The default `party` in ea
 Let's send a request to the room's public URL:
 
 ```ts
-fetch(`${PARTYKIT_HOST}/parties/main/${roomId}`, { 
-  method: "POST", 
+fetch(`${PARTYKIT_HOST}/parties/main/${roomId}`, {
+  method: "POST",
   body: JSON.stringify({
-    message: "Hello!"
-  })
+    message: "Hello!",
+  }),
 });
 ```
-
 
 ### Handle incoming requests
 
 To handle incoming requests, define an `onRequest` handler in your PartyKit server:
+
 ```ts
+import type * as Party from "partykit/server";
 
-import type { Party, PartyRequest, PartyServer } from "partykit/server";
-
-export default class MessageServer implements PartyServer {
+export default class MessageServer implements Party.Server {
   messages: string[] = [];
-  constructor(readonly party: Party) {}
+  constructor(readonly party: Party.Party) {}
 
-  async onRequest(request: PartyRequest) {
+  async onRequest(request: Party.Request) {
     // push new message
     if (request.method === "POST") {
       const payload = await request.json<{ message: string }>();
@@ -61,7 +60,7 @@ The above code snippet implements a simple stateful HTTP server, but did you not
 this.party.broadcast(payload.message);
 ```
 
-The `onRequest` method has access to all of the room's resources, including connected WebSocket clients. 
+The `onRequest` method has access to all of the room's resources, including connected WebSocket clients.
 
 As simple as this sounds, this is a powerful pattern. Being able to access the same party state with both WebSockets and HTTP requests enables us to create flexible push/pull systems that integrate well with third-party systems such as:
 

--- a/apps/docs/src/content/docs/guides/serving-static-assets.md
+++ b/apps/docs/src/content/docs/guides/serving-static-assets.md
@@ -35,7 +35,7 @@ While PartyKit defaults should satisfy most needs, you can override some optiona
     edgeTTL: 1000 * 60 * 60 * 24 * 365, // any number of seconds
 
 
-    // COMING SOON: serve in "single page app" mode
+    // serve in "single page app" mode
     serveSinglePageApp: true
     // COMING SOON: exclude files from being served
     exclude: ["**/*.map"] // PartyKit already excludes dotfiles and node_modules

--- a/apps/docs/src/content/docs/guides/using-multiple-parties-per-project.md
+++ b/apps/docs/src/content/docs/guides/using-multiple-parties-per-project.md
@@ -8,11 +8,12 @@ By default, each PartyKit project defines one party called `main`:
 ```json
 {
   "name": "onbefore",
-  "main": "src/server.ts",
+  "main": "src/server.ts"
 }
 ```
 
 <!-- TODO: Link to reference -->
+
 In addition to the `main` party, each project can define any number of additional parties using the `parties` configuration key in its `partykit.json`:
 
 ```json
@@ -41,7 +42,7 @@ To connect to a party using [`PartySocket`](/reference/partysocket-api/), specif
 const partySocket = new PartySocket({
   host: PARTYKIT_HOST,
   room: "room-id",
-  party: "connections"
+  party: "connections",
 });
 ```
 
@@ -78,11 +79,11 @@ You can define a `connections` party that keeps track of the number of active co
 
 ```ts
 // src/connections.ts
-export default class Rooms implements PartyServer {
+export default class Rooms implements Party.Server {
   connections: Record<string, number> | undefined;
   constructor(readonly party: Party) {}
 
-  async onRequest(request: PartyRequest) {
+  async onRequest(request: Party.Request) {
     // read from storage
     this.connections =
       this.connections ?? (await this.party.storage.get("connections")) ?? {};
@@ -90,9 +91,9 @@ export default class Rooms implements PartyServer {
     if (request.method === "POST") {
       const update = await request.json();
       const count = this.connections[update.roomId] ?? 0;
-      if (update.type === "connect") 
+      if (update.type === "connect")
         this.connections[update.roomId] = count + 1;
-      if (update.type === "disconnect") 
+      if (update.type === "disconnect")
         this.connections[update.roomId] = Math.max(0, count - 1);
 
       // notify any connected listeners
@@ -112,18 +113,18 @@ Any other party can notify the `connections` party of connection/disconnection e
 
 ```ts
 // src/main.ts
-export default class Server implements PartyServer {
-  constructor(readonly party: Party) {}
+export default class Server implements Party.Server {
+  constructor(readonly party: Party.Party) {}
 
-  async onConnect(connection: PartyConnection, ctx: PartyConnectionContext) {
+  async onConnect(connection: Party.Connection, ctx: Party.ConnectionContext) {
     this.updateConnections("connect", connection);
   }
-  async onClose(connection: PartyConnection) {
+  async onClose(connection: Party.Connection) {
     this.updateConnections("disconnect", connection);
   }
   async updateConnections(
     type: "connect" | "disconnect",
-    connection: PartyConnection
+    connection: Party.Connection
   ) {
     // get handle to a shared room instance of the "connections" party
     const connectionsParty = this.party.context.parties.connections;

--- a/apps/docs/src/content/docs/how-partykit-works.md
+++ b/apps/docs/src/content/docs/how-partykit-works.md
@@ -9,7 +9,7 @@ PartyKit simplifies developing real-time and multiplayer applications. To unders
 
 PartyKit is a deployment and hosting platform for **globally distributed**, **stateful**, **on-demand**, **programmable** **web servers**. In practice, this means that:
 
-- You **implement** the server code using [the `PartyServer` JS/TS API](/reference/partyserver-api).
+- You **implement** the server code using [the `Party.Server` JS/TS API](/reference/partyserver-api).
 - You **deploy** the server to the PartyKit runtime using [the `partykit` CLI](/reference/partykit-cli).
 - We **host** the servers on [the PartyKit runtime](#partykit-runtime).
 
@@ -23,7 +23,7 @@ In addition to running modern JavaScript, it also supports [TypeScript](https://
 
 ## PartyKit servers
 
-Above, we described PartyKit as a hosting platform for  **globally distributed**, **stateful**, **on-demand**, **programmable** **web servers**.
+Above, we described PartyKit as a hosting platform for **globally distributed**, **stateful**, **on-demand**, **programmable** **web servers**.
 
 That's a lot of words! Let's unpack them, one by one.
 
@@ -32,17 +32,20 @@ That's a lot of words! Let's unpack them, one by one.
 Each PartyKit server (also known as a **Party**), is backed by a Cloudflare [Durable Object](/glossary/#durable-object).
 
 You can communicate with a Party with standard HTTP requests:
+
 ```ts
-fetch(`https://${project}.${user}.partykit.dev/parties/main/${id}`, { method: "GET"});
+fetch(`https://${project}.${user}.partykit.dev/parties/main/${id}`, {
+  method: "GET",
+});
 ```
 
 More interestingly, you can also connect to a Party using standard WebSockets, enabling real-time push between client and the party instance (also known as "room"):
 
 ```ts
-new WebSocket(`https://${project}.${user}.partykit.dev/parties/main/${id}`)
+new WebSocket(`https://${project}.${user}.partykit.dev/parties/main/${id}`);
 ```
 
-Because the Party server uses standard HTTP and WebSocket protocols, you can connect to them from anywhere: web browsers, native mobile apps, or embedded devices. 
+Because the Party server uses standard HTTP and WebSocket protocols, you can connect to them from anywhere: web browsers, native mobile apps, or embedded devices.
 
 PartyKit also provides optional client SDKs, such as the [PartySocket](/reference/partysocket-api/) JavaScript/TypeScript client.
 

--- a/examples/class/src/server.ts
+++ b/examples/class/src/server.ts
@@ -1,30 +1,22 @@
-import type {
-  Party,
-  PartyConnection,
-  PartyRequest,
-  PartyServer,
-  PartyWorker,
-  PartyServerOptions,
-  PartyConnectionContext,
-} from "partykit/server";
+import type * as Party from "partykit/server";
 
 // PartyKit servers now implement PartyServer interface
-export default class Main implements PartyServer {
+export default class Main implements Party.Server {
   // onBefore* handlers that run in the worker nearest the user are now
   // explicitly marked static, because they have no access to Party state
-  static async onBeforeRequest(req: PartyRequest) {
+  static async onBeforeRequest(req: Party.Request) {
     return req;
   }
-  static async onBeforeConnect(req: PartyRequest) {
+  static async onBeforeConnect(req: Party.Request) {
     return req;
   }
   // onFetch is now stable. No more unstable_onFetch
-  static async onFetch(req: PartyRequest) {
+  static async onFetch(req: Party.Request) {
     return new Response("Unrecognized request: " + req.url, { status: 404 });
   }
 
   // Opting into hibernation is now an explicit option
-  readonly options: PartyServerOptions = {
+  readonly options: Party.ServerOptions = {
     hibernate: true,
   };
 
@@ -33,10 +25,8 @@ export default class Main implements PartyServer {
 
   // PartyServer receives the Party (previous PartyKitRoom) as a constructor argument
   // instead of receiving the `room` argument in each method.
-  readonly party: Party;
-  constructor(party: Party) {
-    this.party = party;
-  }
+
+  constructor(public party: Party.Party) {}
 
   // There's now a new lifecycle method `onStart` which fires before first connection
   // or request to the room. You can use this to load data from storage and perform other
@@ -47,18 +37,21 @@ export default class Main implements PartyServer {
   }
 
   // You can now tag connections, and retrieve tagged connections using Party.getConnections()
-  getConnectionTags(connection: PartyConnection, ctx: PartyConnectionContext) {
+  getConnectionTags(
+    connection: Party.Connection,
+    ctx: Party.ConnectionContext
+  ) {
     const country = (ctx.request.cf?.country as string) ?? "unknown";
     return [country];
   }
 
   // onConnect, onRequest, onAlarm no longer receive the room argument.
-  async onRequest(_req: PartyRequest) {
+  async onRequest(_req: Party.Request) {
     return new Response(
       `Party ${this.party.id} has received ${this.messages.length} messages`
     );
   }
-  async onConnect(connection: PartyConnection, ctx: PartyConnectionContext) {
+  async onConnect(connection: Party.Connection, ctx: Party.ConnectionContext) {
     // You can now read the room state from `this.party` instead.
     this.party.broadcast(
       "A new connection has joined the party! Say hello to " + connection.id
@@ -75,17 +68,17 @@ export default class Main implements PartyServer {
   // Previously onMessage, onError, onClose were only called for hibernating parties.
   // They're now available for all parties, so you no longer need to manually
   // manage event handlers in onConnect!
-  async onMessage(message: string, connection: PartyConnection) {
+  async onMessage(message: string, connection: Party.Connection) {
     connection.send("Pong!");
     this.party.broadcast(message, [connection.id]);
   }
-  async onError(connection: PartyConnection, err: Error) {
+  async onError(connection: Party.Connection, err: Error) {
     console.log("Error from " + connection.id, err.message);
   }
-  async onClose(connection: PartyConnection) {
+  async onClose(connection: Party.Connection) {
     console.log("Closed " + connection.id);
   }
 }
 
 // Optional: Typecheck the static methods with a `satisfies` statement.
-Main satisfies PartyWorker;
+Main satisfies Party.Worker;

--- a/packages/create-partykit/js-template/src/server.js
+++ b/packages/create-partykit/js-template/src/server.js
@@ -3,22 +3,22 @@
 // @ts-check
 // Optional JS type checking, powered by TypeScript.
 /** @typedef {import("partykit/server").Party} Party */
-/** @typedef {import("partykit/server").PartyServer} PartyServer */
-/** @typedef {import("partykit/server").PartyConnection} PartyConnection */
-/** @typedef {import("partykit/server").PartyConnectionContext} PartyConnectionContext */
+/** @typedef {import("partykit/server").Server} Server */
+/** @typedef {import("partykit/server").Connection} Connection */
+/** @typedef {import("partykit/server").ConnectionContext} ConnectionContext */
 
 /**
- * @implements {PartyServer}
+ * @implements {Server}
  */
-class Server {
+class PartyServer {
   constructor(party) {
     /** @type {Party} */
     this.party = party;
   }
 
   /**
-   * @param {PartyConnection} conn - The connection object.
-   * @param {PartyConnectionContext} ctx - The context object.
+   * @param {Connection} conn - The connection object.
+   * @param {ConnectionContext} ctx - The context object.
    */
   onConnect(conn, ctx) {
     // A websocket just connected!
@@ -35,7 +35,7 @@ class Server {
 
   /**
    * @param {string} message
-   * @param {PartyConnection} sender
+   * @param {Connection} sender
    */
   onMessage(message, sender) {
     console.log(`connection ${sender.id} sent message: ${message}`);
@@ -44,4 +44,4 @@ class Server {
   }
 }
 
-export default Server;
+export default PartyServer;

--- a/packages/create-partykit/ts-template/src/server.ts
+++ b/packages/create-partykit/ts-template/src/server.ts
@@ -1,15 +1,9 @@
-import type {
-  Party,
-  PartyConnection,
-  PartyConnectionContext,
-  PartyServer,
-  PartyWorker,
-} from "partykit/server";
+import type * as Party from "partykit/server";
 
-export default class Server implements PartyServer {
-  constructor(readonly party: Party) {}
+export default class Server implements Party.Server {
+  constructor(readonly party: Party.Party) {}
 
-  onConnect(conn: PartyConnection, ctx: PartyConnectionContext) {
+  onConnect(conn: Party.Connection, ctx: Party.ConnectionContext) {
     // A websocket just connected!
     console.log(
       `Connected:
@@ -22,7 +16,7 @@ export default class Server implements PartyServer {
     conn.send("hello from server");
   }
 
-  onMessage(message: string, sender: PartyConnection) {
+  onMessage(message: string, sender: Party.Connection) {
     // let's log the message
     console.log(`connection ${sender.id} sent message: ${message}`);
     // as well as broadcast it to all the other connections in the room...
@@ -34,4 +28,4 @@ export default class Server implements PartyServer {
   }
 }
 
-Server satisfies PartyWorker;
+Server satisfies Party.Worker;

--- a/packages/partykit/init/index.js
+++ b/packages/partykit/init/index.js
@@ -3,22 +3,25 @@
 // @ts-check
 // Optional JS type checking, powered by TypeScript.
 /** @typedef {import("partykit/server").Party} Party */
-/** @typedef {import("partykit/server").PartyServer} PartyServer */
-/** @typedef {import("partykit/server").PartyConnection} PartyConnection */
-/** @typedef {import("partykit/server").PartyConnectionContext} PartyConnectionContext */
+/** @typedef {import("partykit/server").Server} Server */
+/** @typedef {import("partykit/server").Connection} Connection */
+/** @typedef {import("partykit/server").ConnectionContext} ConnectionContext */
 
 /**
- * @implements {PartyServer}
+ * @implements {Server}
  */
-class Server {
+class PartyServer {
+  /**
+   * @param {Party} party - The Party object.
+   */
   constructor(party) {
     /** @type {Party} */
     this.party = party;
   }
 
   /**
-   * @param {PartyConnection} conn - The connection object.
-   * @param {PartyConnectionContext} ctx - The context object.
+   * @param {Connection} conn - The connection object.
+   * @param {ConnectionContext} ctx - The context object.
    */
   onConnect(conn, ctx) {
     // A websocket just connected!
@@ -35,7 +38,7 @@ class Server {
 
   /**
    * @param {string} message
-   * @param {PartyConnection} sender
+   * @param {Connection} sender
    */
   onMessage(message, sender) {
     console.log(`connection ${sender.id} sent message: ${message}`);
@@ -44,4 +47,4 @@ class Server {
   }
 }
 
-export default Server;
+export default PartyServer;

--- a/packages/partykit/init/index.ts
+++ b/packages/partykit/init/index.ts
@@ -1,15 +1,9 @@
-import type {
-  Party,
-  PartyConnection,
-  PartyConnectionContext,
-  PartyServer,
-  PartyWorker,
-} from "partykit/server";
+import type * as Party from "partykit/server";
 
-export default class Server implements PartyServer {
-  constructor(readonly party: Party) {}
+export default class Server implements Party.Server {
+  constructor(readonly party: Party.Party) {}
 
-  onConnect(conn: PartyConnection, ctx: PartyConnectionContext) {
+  onConnect(conn: Party.Connection, ctx: Party.ConnectionContext) {
     // A websocket just connected!
     console.log(
       `Connected:
@@ -22,7 +16,7 @@ export default class Server implements PartyServer {
     conn.send("hello from server");
   }
 
-  onMessage(message: string, sender: PartyConnection) {
+  onMessage(message: string, sender: Party.Connection) {
     // let's log the message
     console.log(`connection ${sender.id} sent message: ${message}`);
     // as well as broadcast it to all the other connections in the room...
@@ -34,4 +28,4 @@ export default class Server implements PartyServer {
   }
 }
 
-Server satisfies PartyWorker;
+Server satisfies Party.Worker;

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -329,14 +329,11 @@ export type ServerOptions = {
 // ---
 //
 
-// Extend type so that when language server (e.g. vscode) autocompletes,
-// it will import this type instead of the underlying type directly.
 /** @deprecated use Party.Request instead */
-export interface PartyRequest extends Request {}
+export type PartyRequest = Request;
 
-/** Per-party key-value storage */
 /** @deprecated use Party.Storage instead */
-export interface PartyStorage extends Storage {}
+export type PartyStorage = Storage;
 
 /** @deprecated use Party.Storage instead */
 export type PartyKitStorage = Storage;
@@ -348,181 +345,29 @@ export type PartyConnectionContext = { request: CFRequest };
 export type PartyKitContext = ConnectionContext;
 
 /** @deprecated use Party.Stub instead */
-export type PartyStub = {
-  connect: () => WebSocket;
-  fetch: (init?: RequestInit) => Promise<Response>;
-};
+export type PartyStub = Stub;
 
 /** Additional information about other resources in the current project */
 /** @deprecated use Party.Context instead */
-export type PartyContext = {
-  /** Access other parties in this project */
-  parties: Record<
-    string,
-    {
-      get(id: string): Stub;
-    }
-  >;
-};
+export type PartyContext = Context;
 
 /** @deprecated use Party.FetchLobby instead */
-export type PartyFetchLobby = {
-  env: Record<string, unknown>;
-  parties: Context["parties"];
-};
+export type PartyFetchLobby = FetchLobby;
 
 /** @deprecated use Party.Lobby instead */
-export type PartyLobby = {
-  id: string;
-  env: Record<string, unknown>;
-  parties: Context["parties"];
-};
+export type PartyLobby = Lobby;
 
 /** @deprecated use Party.ExecutionContext instead */
 export type PartyExecutionContext = CFExecutionContext;
 
-/** A WebSocket connected to the Party */
 /** @deprecated use Party.Connection instead */
-export type PartyConnection = WebSocket & {
-  /** Connection identifier */
-  id: string;
+export type PartyConnection = Connection;
 
-  /** @deprecated You can access the socket properties directly on the connection*/
-  socket: WebSocket;
-  // We would have been able to use Websocket::url
-  // but it's not available in the Workers runtime
-  // (rather, url is `null` when using WebSocketPair)
-  // It's also set as readonly, so we can't set it ourselves.
-  // Instead, we'll use the `uri` property.
-  uri: string;
-};
-
-/**
- * Party.Server defines what happens when someone connects to and sends messages or HTTP requests to your party
- *
- * @example
- * export default class Room implements Party.Server {
- *   constructor(readonly party: Party) {}
- *   onConnect(connection: Party.Connection) {
- *     this.party.broadcast("Someone connected with id " + connection.id);
- *   }
- * }
- */
 /** @deprecated use Party.Server instead */
-export interface PartyServer {
-  /**
-   * You can define an `options` field to customise the Party.Server behaviour.
-   */
-  readonly options?: ServerOptions;
+export type PartyServer = Server;
 
-  /**
-   * You can tag a connection to filter them in Party#getConnections.
-   * Each connection supports up to 9 tags, each tag max length is 256 characters.
-   */
-  getConnectionTags?(
-    connection: Connection,
-    context: ConnectionContext
-  ): string[] | Promise<string[]>;
-
-  /**
-   * Called when the server is started, before first `onConnect` or `onRequest`.
-   * Useful for loading data from storage.
-   *
-   * You can use this to load data from storage and perform other asynchronous
-   * initialization, such as retrieving data or configuration from other
-   * services or databases.
-   */
-  onStart?(): void | Promise<void>;
-
-  /**
-   * Called when a new incoming WebSocket connection is opened.
-   */
-  onConnect?(
-    connection: Connection,
-    ctx: ConnectionContext
-  ): void | Promise<void>;
-
-  /**
-   * Called when a WebSocket connection receives a message from a client, or another connected party.
-   */
-  onMessage?(
-    message: string | ArrayBuffer,
-    sender: Connection
-  ): void | Promise<void>;
-
-  /**
-   * Called when a WebSocket connection is closed by the client.
-   */
-  onClose?(connection: Connection): void | Promise<void>;
-
-  /**
-   * Called when a WebSocket connection is closed due to a connection error.
-   */
-  onError?(connection: Connection, error: Error): void | Promise<void>;
-
-  /**
-   * Called when a HTTP request is made to the party URL.
-   */
-  onRequest?(req: Request): Response | Promise<Response>;
-
-  /**
-   * Called when an alarm is triggered. Use Party.storage.setAlarm to set an alarm.
-   *
-   * Alarms have access to most Party resources such as storage, but not Party.id
-   * and Party.context.parties properties. Attempting to access them will result in a
-   * runtime error.
-   */
-  onAlarm?(): void | Promise<void>;
-}
-
-/**
- * Party.Worker allows you to customise the behaviour of the Edge worker that routes
- * connections to your party.
- *
- * The Party.Worker methods can be defined as static methods on the PartyServer constructor.
- * @example
- * export default class Room implements Party.Server {
- *   static onBeforeConnect(req: Party.Request) {
- *     return new Response("Access denied", { status: 403 })
- *   }
- *   constructor(readonly party: Party) {}
- * }
- *
- * Room satisfies PartyWorker;
- */
 /** @deprecated use Party.Worker instead */
-export type PartyWorker = ServerConstructor & {
-  /**
-   * Runs on any HTTP request that does not match a Party URL or a static asset.
-   * Useful for running lightweight HTTP endpoints that don't need access to the Party
-   * state.
-   **/
-  onFetch?(
-    req: Request,
-    lobby: FetchLobby,
-    ctx: ExecutionContext
-  ): Response | Promise<Response>;
-
-  /**
-   * Runs before any HTTP request is made to the party. You can modify the request
-   * before it is forwarded to the party, or return a Response to short-circuit it.
-   */
-  onBeforeRequest?(
-    req: Request,
-    lobby: Lobby,
-    ctx: ExecutionContext
-  ): Request | Response | Promise<Request | Response>;
-
-  /**
-   * Runs before any WebSocket connection is made to the party. You can modify the request
-   * before opening a connection, or return a Response to prevent the connection.
-   */
-  onBeforeConnect?(
-    req: Request,
-    lobby: Lobby,
-    ctx: ExecutionContext
-  ): Request | Response | Promise<Request | Response>;
-};
+export type PartyWorker = Worker;
 
 /** @deprecated Use `Party` instead */
 export type PartyKitRoom = Party;
@@ -531,12 +376,4 @@ export type PartyKitRoom = Party;
 export type PartyKitConnection = Connection;
 
 /** @deprecated Use `Party.ServerOptions` instead */
-export type PartyServerOptions = {
-  /**
-   * Whether the PartyKit platform should remove the server from memory
-   * between HTTP requests and WebSocket messages.
-   *
-   * The default value is `false`.
-   */
-  hibernate?: boolean;
-};
+export type PartyServerOptions = ServerOptions;

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -1,6 +1,6 @@
 import type {
   DurableObjectStorage,
-  ExecutionContext,
+  ExecutionContext as CFExecutionContext,
   WebSocket,
   Request as CFRequest,
 } from "@cloudflare/workers-types";
@@ -13,64 +13,60 @@ export type StaticAssetsManifestType = {
   assets: Record<string, string>;
 };
 
+type StandardRequest = globalThis.Request;
+
 // Types with PartyKit* prefix are used in module workers, i.e.
 // `export default {} satisfies PartyKitServer;`
 
-// Types with Party* prefix are used in class workers, i.e.
-// `export default class Room implements PartyServer {}`
+// Types with Party.* prefix are used in class workers, i.e.
+// `export default class Room implements Party.Server {}`
 
 // Extend type so that when language server (e.g. vscode) autocompletes,
 // it will import this type instead of the underlying type directly.
-export interface PartyRequest extends CFRequest {}
+export interface Request extends CFRequest {}
 
 // Because when you construct a `new Request()` in a user script,
 // it's assumed to be a standards-based Fetch API Response, unless overridden.
 // This is fine by us, let user return whichever request type
-type ReturnRequest = Request | PartyRequest;
+type ReturnRequest = StandardRequest | CFRequest;
 
 /** Per-party key-value storage */
-export interface PartyStorage extends DurableObjectStorage {}
-
-/** @deprecated use PartyStorage instead */
-export type PartyKitStorage = PartyStorage;
+export interface Storage extends DurableObjectStorage {}
 
 /** Connection metadata only available when the connection is made */
-export type PartyConnectionContext = { request: PartyRequest };
+export type ConnectionContext = { request: CFRequest };
 
-/** @deprecated use PartyConnectionContext instead */
-export type PartyKitContext = PartyConnectionContext;
-
-export type PartyStub = {
+export type Stub = {
   connect: () => WebSocket;
   fetch: (init?: RequestInit) => Promise<Response>;
 };
 
 /** Additional information about other resources in the current project */
-export type PartyContext = {
+export type Context = {
   /** Access other parties in this project */
   parties: Record<
     string,
     {
-      get(id: string): PartyStub;
+      get(id: string): Stub;
     }
   >;
 };
 
-export type PartyFetchLobby = {
+export type FetchLobby = {
   env: Record<string, unknown>;
-  parties: PartyContext["parties"];
+  parties: Context["parties"];
 };
 
-export type PartyLobby = {
+export type Lobby = {
   id: string;
   env: Record<string, unknown>;
-  parties: PartyContext["parties"];
+  parties: Context["parties"];
 };
 
-export type PartyExecutionContext = ExecutionContext;
+export type ExecutionContext = CFExecutionContext;
 
 /** A WebSocket connected to the Party */
-export type PartyConnection = WebSocket & {
+export type Connection = WebSocket & {
   /** Connection identifier */
   id: string;
 
@@ -96,56 +92,53 @@ export type Party = {
   env: Record<string, unknown>;
 
   /** A per-party key-value storage */
-  storage: PartyStorage;
+  storage: Storage;
 
   /** Additional information about other resources in the current project */
-  context: PartyContext;
+  context: Context;
 
   /** @deprecated Use `party.getConnections` instead */
-  connections: Map<string, PartyConnection>;
+  connections: Map<string, Connection>;
 
   /** @deprecated Use `party.context.parties` instead */
-  parties: PartyContext["parties"];
+  parties: Context["parties"];
 
   /** Send a message to all connected clients, except connection ids listed `without` */
   broadcast: (msg: string, without?: string[] | undefined) => void;
 
   /** Get a connection by connection id */
-  getConnection(id: string): PartyConnection | undefined;
+  getConnection(id: string): Connection | undefined;
 
   /**
    * Get all connections. Optionally, you can provide a tag to filter returned connections.
-   * Use `PartyServer#getConnectionTags` to tag the connection on connect.
+   * Use `Party.Server#getConnectionTags` to tag the connection on connect.
    */
-  getConnections(tag?: string): Iterable<PartyConnection>;
+  getConnections(tag?: string): Iterable<Connection>;
 };
 
-/**
- * PartyServer defines what happens when someone connects to and sends messages or HTTP requests to your party
+/* Party.Server defines what happens when someone connects to and sends messages or HTTP requests to your party
  *
  * @example
- * export default class Room implements PartyServer {
+ * export default class Room implements Party.Server {
  *   constructor(readonly party: Party) {}
- *   onConnect(connection: PartyConnection) {
+ *   onConnect(connection: Party.Connection) {
  *     this.party.broadcast("Someone connected with id " + connection.id);
  *   }
  * }
  */
-export interface PartyServer {
-  // readonly party: Party;
-
+export type Server = {
   /**
-   * You can define an `options` field to customise the PartyServer behaviour.
+   * You can define an `options` field to customise the Party.Server behaviour.
    */
-  readonly options?: PartyServerOptions;
+  readonly options?: ServerOptions;
 
   /**
    * You can tag a connection to filter them in Party#getConnections.
    * Each connection supports up to 9 tags, each tag max length is 256 characters.
    */
   getConnectionTags?(
-    connection: PartyConnection,
-    context: PartyConnectionContext
+    connection: Connection,
+    context: ConnectionContext
   ): string[] | Promise<string[]>;
 
   /**
@@ -162,8 +155,8 @@ export interface PartyServer {
    * Called when a new incoming WebSocket connection is opened.
    */
   onConnect?(
-    connection: PartyConnection,
-    ctx: PartyConnectionContext
+    connection: Connection,
+    ctx: ConnectionContext
   ): void | Promise<void>;
 
   /**
@@ -171,23 +164,23 @@ export interface PartyServer {
    */
   onMessage?(
     message: string | ArrayBuffer,
-    sender: PartyConnection
+    sender: Connection
   ): void | Promise<void>;
 
   /**
    * Called when a WebSocket connection is closed by the client.
    */
-  onClose?(connection: PartyConnection): void | Promise<void>;
+  onClose?(connection: Connection): void | Promise<void>;
 
   /**
    * Called when a WebSocket connection is closed due to a connection error.
    */
-  onError?(connection: PartyConnection, error: Error): void | Promise<void>;
+  onError?(connection: Connection, error: Error): void | Promise<void>;
 
   /**
    * Called when a HTTP request is made to the party URL.
    */
-  onRequest?(req: PartyRequest): Response | Promise<Response>;
+  onRequest?(req: Request): Response | Promise<Response>;
 
   /**
    * Called when an alarm is triggered. Use Party.storage.setAlarm to set an alarm.
@@ -197,37 +190,37 @@ export interface PartyServer {
    * runtime error.
    */
   onAlarm?(): void | Promise<void>;
-}
+};
 
-type PartyServerConstructor = {
-  new (party: Party): PartyServer;
+type ServerConstructor = {
+  new (party: Party): Server;
 };
 
 /**
- * PartyWorker allows you to customise the behaviour of the Edge worker that routes
+ * Party.Worker allows you to customise the behaviour of the Edge worker that routes
  * connections to your party.
  *
- * The PartyWorker methods can be defined as static methods on the PartyServer constructor.
+ * The Party.Worker methods can be defined as static methods on the Party.Server constructor.
  * @example
- * export default class Room implements PartyServer {
- *   static onBeforeConnect(req: PartyRequest) {
+ * export default class Room implements Party.Server {
+ *   static onBeforeConnect(req: Party.Request) {
  *     return new Response("Access denied", { status: 403 })
  *   }
  *   constructor(readonly party: Party) {}
  * }
  *
- * Room satisfies PartyWorker;
+ * Room satisfies Party.Worker;
  */
-export type PartyWorker = PartyServerConstructor & {
+export type Worker = ServerConstructor & {
   /**
    * Runs on any HTTP request that does not match a Party URL or a static asset.
    * Useful for running lightweight HTTP endpoints that don't need access to the Party
    * state.
    **/
   onFetch?(
-    req: PartyRequest,
-    lobby: PartyFetchLobby,
-    ctx: PartyExecutionContext
+    req: Request,
+    lobby: FetchLobby,
+    ctx: ExecutionContext
   ): Response | Promise<Response>;
 
   /**
@@ -235,27 +228,27 @@ export type PartyWorker = PartyServerConstructor & {
    * before it is forwarded to the party, or return a Response to short-circuit it.
    */
   onBeforeRequest?(
-    req: PartyRequest,
-    lobby: PartyLobby,
-    ctx: PartyExecutionContext
-  ): PartyRequest | Response | Promise<PartyRequest | Response>;
+    req: Request,
+    lobby: Lobby,
+    ctx: ExecutionContext
+  ): Request | Response | Promise<Request | Response>;
 
   /**
    * Runs before any WebSocket connection is made to the party. You can modify the request
    * before opening a connection, or return a Response to prevent the connection.
    */
   onBeforeConnect?(
-    req: PartyRequest,
-    lobby: PartyLobby,
-    ctx: PartyExecutionContext
-  ): PartyRequest | Response | Promise<PartyRequest | Response>;
+    req: Request,
+    lobby: Lobby,
+    ctx: ExecutionContext
+  ): Request | Response | Promise<Request | Response>;
 };
 
 /**
  * PartyKitServer is allows you to customise the behaviour of your Party.
  *
  * @note If you're starting a new project, we recommend using the newer
- * PartyServer API instead.
+ * Party.Server API instead.
  *
  * @example
  * export default {
@@ -267,40 +260,40 @@ export type PartyWorker = PartyServerConstructor & {
 export type PartyKitServer = {
   /** @deprecated. Use `onFetch` instead */
   unstable_onFetch?: (
-    req: PartyRequest,
-    lobby: PartyFetchLobby,
-    ctx: PartyExecutionContext
+    req: Request,
+    lobby: FetchLobby,
+    ctx: ExecutionContext
   ) => Response | Promise<Response>;
   onFetch?: (
-    req: PartyRequest,
-    lobby: PartyFetchLobby,
-    ctx: PartyExecutionContext
+    req: Request,
+    lobby: FetchLobby,
+    ctx: ExecutionContext
   ) => Response | Promise<Response>;
   onBeforeRequest?: (
-    req: PartyRequest,
+    req: Request,
     party: {
       id: string;
       env: Record<string, unknown>;
-      parties: PartyContext["parties"];
+      parties: Context["parties"];
     },
-    ctx: PartyExecutionContext
+    ctx: ExecutionContext
   ) => ReturnRequest | Response | Promise<ReturnRequest | Response>;
 
-  onRequest?: (req: PartyRequest, party: Party) => Response | Promise<Response>;
+  onRequest?: (req: Request, party: Party) => Response | Promise<Response>;
   onAlarm?: (party: Omit<Party, "id" | "parties">) => void | Promise<void>;
   onConnect?: (
-    connection: PartyConnection,
+    connection: Connection,
     party: Party,
-    ctx: PartyConnectionContext
+    ctx: ConnectionContext
   ) => void | Promise<void>;
   onBeforeConnect?: (
-    req: PartyRequest,
+    req: Request,
     party: {
       id: string;
       env: Record<string, unknown>;
-      parties: PartyContext["parties"];
+      parties: Context["parties"];
     },
-    ctx: PartyExecutionContext
+    ctx: ExecutionContext
   ) => ReturnRequest | Response | Promise<ReturnRequest | Response>;
 
   /**
@@ -309,23 +302,235 @@ export type PartyKitServer = {
    */
   onMessage?: (
     message: string | ArrayBuffer,
-    connection: PartyConnection,
+    connection: Connection,
     party: Party
   ) => void | Promise<void>;
-  onClose?: (connection: PartyConnection, party: Party) => void | Promise<void>;
+  onClose?: (connection: Connection, party: Party) => void | Promise<void>;
   onError?: (
-    connection: PartyConnection,
+    connection: Connection,
     err: Error,
     party: Party
   ) => void | Promise<void>;
 };
 
+export type ServerOptions = {
+  /**
+   * Whether the PartyKit platform should remove the server from memory
+   * between HTTP requests and WebSocket messages.
+   *
+   * The default value is `false`.
+   */
+  hibernate?: boolean;
+};
+
+//
+// ---
+// DEPRECATIONS
+// ---
+//
+
+// Extend type so that when language server (e.g. vscode) autocompletes,
+// it will import this type instead of the underlying type directly.
+/** @deprecated use Party.Request instead */
+export interface PartyRequest extends Request {}
+
+/** Per-party key-value storage */
+/** @deprecated use Party.Storage instead */
+export interface PartyStorage extends Storage {}
+
+/** @deprecated use Party.Storage instead */
+export type PartyKitStorage = Storage;
+
+/** @deprecated use Party.ConnectionContext instead */
+export type PartyConnectionContext = { request: CFRequest };
+
+/** @deprecated use Party.ConnectionContext instead */
+export type PartyKitContext = ConnectionContext;
+
+/** @deprecated use Party.Stub instead */
+export type PartyStub = {
+  connect: () => WebSocket;
+  fetch: (init?: RequestInit) => Promise<Response>;
+};
+
+/** Additional information about other resources in the current project */
+/** @deprecated use Party.Context instead */
+export type PartyContext = {
+  /** Access other parties in this project */
+  parties: Record<
+    string,
+    {
+      get(id: string): Stub;
+    }
+  >;
+};
+
+/** @deprecated use Party.FetchLobby instead */
+export type PartyFetchLobby = {
+  env: Record<string, unknown>;
+  parties: Context["parties"];
+};
+
+/** @deprecated use Party.Lobby instead */
+export type PartyLobby = {
+  id: string;
+  env: Record<string, unknown>;
+  parties: Context["parties"];
+};
+
+/** @deprecated use Party.ExecutionContext instead */
+export type PartyExecutionContext = CFExecutionContext;
+
+/** A WebSocket connected to the Party */
+/** @deprecated use Party.Connection instead */
+export type PartyConnection = WebSocket & {
+  /** Connection identifier */
+  id: string;
+
+  /** @deprecated You can access the socket properties directly on the connection*/
+  socket: WebSocket;
+  // We would have been able to use Websocket::url
+  // but it's not available in the Workers runtime
+  // (rather, url is `null` when using WebSocketPair)
+  // It's also set as readonly, so we can't set it ourselves.
+  // Instead, we'll use the `uri` property.
+  uri: string;
+};
+
+/**
+ * Party.Server defines what happens when someone connects to and sends messages or HTTP requests to your party
+ *
+ * @example
+ * export default class Room implements Party.Server {
+ *   constructor(readonly party: Party) {}
+ *   onConnect(connection: Party.Connection) {
+ *     this.party.broadcast("Someone connected with id " + connection.id);
+ *   }
+ * }
+ */
+/** @deprecated use Party.Server instead */
+export interface PartyServer {
+  /**
+   * You can define an `options` field to customise the Party.Server behaviour.
+   */
+  readonly options?: ServerOptions;
+
+  /**
+   * You can tag a connection to filter them in Party#getConnections.
+   * Each connection supports up to 9 tags, each tag max length is 256 characters.
+   */
+  getConnectionTags?(
+    connection: Connection,
+    context: ConnectionContext
+  ): string[] | Promise<string[]>;
+
+  /**
+   * Called when the server is started, before first `onConnect` or `onRequest`.
+   * Useful for loading data from storage.
+   *
+   * You can use this to load data from storage and perform other asynchronous
+   * initialization, such as retrieving data or configuration from other
+   * services or databases.
+   */
+  onStart?(): void | Promise<void>;
+
+  /**
+   * Called when a new incoming WebSocket connection is opened.
+   */
+  onConnect?(
+    connection: Connection,
+    ctx: ConnectionContext
+  ): void | Promise<void>;
+
+  /**
+   * Called when a WebSocket connection receives a message from a client, or another connected party.
+   */
+  onMessage?(
+    message: string | ArrayBuffer,
+    sender: Connection
+  ): void | Promise<void>;
+
+  /**
+   * Called when a WebSocket connection is closed by the client.
+   */
+  onClose?(connection: Connection): void | Promise<void>;
+
+  /**
+   * Called when a WebSocket connection is closed due to a connection error.
+   */
+  onError?(connection: Connection, error: Error): void | Promise<void>;
+
+  /**
+   * Called when a HTTP request is made to the party URL.
+   */
+  onRequest?(req: Request): Response | Promise<Response>;
+
+  /**
+   * Called when an alarm is triggered. Use Party.storage.setAlarm to set an alarm.
+   *
+   * Alarms have access to most Party resources such as storage, but not Party.id
+   * and Party.context.parties properties. Attempting to access them will result in a
+   * runtime error.
+   */
+  onAlarm?(): void | Promise<void>;
+}
+
+/**
+ * Party.Worker allows you to customise the behaviour of the Edge worker that routes
+ * connections to your party.
+ *
+ * The Party.Worker methods can be defined as static methods on the PartyServer constructor.
+ * @example
+ * export default class Room implements Party.Server {
+ *   static onBeforeConnect(req: Party.Request) {
+ *     return new Response("Access denied", { status: 403 })
+ *   }
+ *   constructor(readonly party: Party) {}
+ * }
+ *
+ * Room satisfies PartyWorker;
+ */
+/** @deprecated use Party.Worker instead */
+export type PartyWorker = ServerConstructor & {
+  /**
+   * Runs on any HTTP request that does not match a Party URL or a static asset.
+   * Useful for running lightweight HTTP endpoints that don't need access to the Party
+   * state.
+   **/
+  onFetch?(
+    req: Request,
+    lobby: FetchLobby,
+    ctx: ExecutionContext
+  ): Response | Promise<Response>;
+
+  /**
+   * Runs before any HTTP request is made to the party. You can modify the request
+   * before it is forwarded to the party, or return a Response to short-circuit it.
+   */
+  onBeforeRequest?(
+    req: Request,
+    lobby: Lobby,
+    ctx: ExecutionContext
+  ): Request | Response | Promise<Request | Response>;
+
+  /**
+   * Runs before any WebSocket connection is made to the party. You can modify the request
+   * before opening a connection, or return a Response to prevent the connection.
+   */
+  onBeforeConnect?(
+    req: Request,
+    lobby: Lobby,
+    ctx: ExecutionContext
+  ): Request | Response | Promise<Request | Response>;
+};
+
 /** @deprecated Use `Party` instead */
 export type PartyKitRoom = Party;
 
-/** @deprecated Use `PartyConnection` instead */
-export type PartyKitConnection = PartyConnection;
+/** @deprecated Use `Party.Connection` instead */
+export type PartyKitConnection = Connection;
 
+/** @deprecated Use `Party.ServerOptions` instead */
 export type PartyServerOptions = {
   /**
    * Whether the PartyKit platform should remove the server from memory


### PR DESCRIPTION
This changes the naming of our exported types from `partykit/server`. The motivation here was aesthetic/simplification. Most of the exports los the `Party` prefix; i.e. `PartyServer` becomes `Server`, `PartyConnection` becomes `Connection`, and so on. If you look at the class example, this doesn't drastically change the code; the import becomes a lot shorter (`import type * as Party from 'partykit/server'` gets all the required types) and required types are taken by `Party.*`.

I also did a run on all the docs/templates and the blog post, but lemme know if I missed anything!