### PR TITLE
Improve YPartyKitProvider errors

### DIFF
--- a/.changeset/ninety-poems-film.md
+++ b/.changeset/ninety-poems-film.md
@@ -1,0 +1,5 @@
+---
+"y-partykit": patch
+---
+
+Better error messages for YPartyKitProvider

--- a/packages/y-partykit/src/provider.ts
+++ b/packages/y-partykit/src/provider.ts
@@ -551,6 +551,14 @@ function generateUUID(): string {
   });
 }
 
+function assertType(value: unknown, label: string, type: string) {
+  if (typeof value !== type) {
+    throw new Error(
+      `Invalid "${label}" parameter provided to YPartyKitProvider. Expected: ${type}, received: ${value}`
+    );
+  }
+}
+
 export default class YPartyKitProvider extends WebsocketProvider {
   id: string;
   constructor(
@@ -561,6 +569,9 @@ export default class YPartyKitProvider extends WebsocketProvider {
       party?: string;
     } = {}
   ) {
+    assertType(host, "host", "string");
+    assertType(room, "room", "string");
+
     // strip the protocol from the beginning of `host` if any
     host = host.replace(/^(http|https|ws|wss):\/\//, "");
 


### PR DESCRIPTION
It's common for `host` and `room` parameters to be accidentally undefined e.g. when an environment variable is not set.

This PR adds better error messages

## Was
```
TypeError: Cannot read properties of undefined (reading 'replace')
```

 ## Now

<img width="951" alt="image" src="https://github.com/partykit/partykit/assets/1203949/025844e9-0abc-41b7-b91b-61da81a3293d">
