### PR TITLE
fix: `init` doesn't install the right versions of packages

### DIFF
--- a/.changeset/modern-steaks-drop.md
+++ b/.changeset/modern-steaks-drop.md
@@ -1,0 +1,10 @@
+---
+"partysocket": patch
+"partykit": patch
+---
+
+fix: `init` doesn't install the right versions of packages
+
+This fix should pick up the latest versions of partykit /partysocket when installing. We were using the previous beta logic when every package was on the same version. This patch picks up the latest versions of both and uses it.
+
+(also sneaking in a quick types fix for usePartySocket)

--- a/packages/partysocket/src/react.ts
+++ b/packages/partysocket/src/react.ts
@@ -56,4 +56,4 @@ export default function usePartySocket(options: UsePartySocketOptions) {
   return socketRef.current;
 }
 
-export const useWebSocket = useWebSocketImpl;
+export { useWebSocketImpl as useWebSocket };


### PR DESCRIPTION
This fix should pick up the latest versions of partykit /partysocket when installing. We were using the previous beta logic when every package was on the same version. This patch picks up the latest versions of both and uses it.

(also sneaking in a quick types fix for usePartySocket)