### PR TITLE
Migrate react-text-loop -> react-text-loop-next-18

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -17,7 +17,7 @@
     "astro": "^2.8.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-text-loop": "^2.3.0"
+    "react-text-loop-next-18": "0.0.3"
   },
   "devDependencies": {
     "@types/react": "^18.2.20",

--- a/apps/site/src/components/HeroLoop.jsx
+++ b/apps/site/src/components/HeroLoop.jsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import TextLoop from "react-text-loop";
+import { TextLoop } from "react-text-loop-next-18";
 
 export default function HeroLoop() {
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "astro": "^2.8.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-text-loop": "^2.3.0"
+        "react-text-loop-next-18": "0.0.3"
       },
       "devDependencies": {
         "@types/react": "^18.2.20",
@@ -24205,11 +24205,6 @@
         "react": ">=16.13.1"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
-    },
     "node_modules/react-icons": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.9.0.tgz",
@@ -24222,6 +24217,19 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/react-motion": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
+      "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
+      "dependencies": {
+        "performance-now": "^0.2.0",
+        "prop-types": "^15.5.8",
+        "raf": "^3.1.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.9 || ^15.3.0 || ^16.0.0"
+      }
     },
     "node_modules/react-reconciler": {
       "version": "0.29.0",
@@ -24277,31 +24285,17 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/react-text-loop": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-text-loop/-/react-text-loop-2.3.0.tgz",
-      "integrity": "sha512-tRLxdkhc1ojAICxERJNOWj3Ry7NIGmFQF4tR6cRVyL+5zVD+gj+8uGPvOgEBLuj2vmjTXLPvBMVVCnoAIy1+DA==",
+    "node_modules/react-text-loop-next-18": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/react-text-loop-next-18/-/react-text-loop-next-18-0.0.3.tgz",
+      "integrity": "sha512-2JiF5T35+gv3VuL5eKNAyPssSZnb6rqTxx6fIcVBbGIxZNjm8F2biOtODHFbZ772xcjGXx3yl1sMa/GWOlzi8w==",
       "dependencies": {
         "cxs": "^6.2.0",
-        "react-fast-compare": "2.0.4",
         "react-motion": "^0.5.2"
       },
       "peerDependencies": {
-        "react": "^15.0.1 || ^16.0.1",
-        "react-dom": "^15.0.1 || ^16.0.1"
-      }
-    },
-    "node_modules/react-text-loop/node_modules/react-motion": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
-      "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
-      "dependencies": {
-        "performance-now": "^0.2.0",
-        "prop-types": "^15.5.8",
-        "raf": "^3.1.0"
-      },
-      "peerDependencies": {
-        "react": "^0.14.9 || ^15.3.0 || ^16.0.0"
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
       }
     },
     "node_modules/react-textarea-autosize": {


### PR DESCRIPTION
Now that the website is in the monorepo, we were getting dependency conflicts for different versions of `react` defined by `peerDependencies` in [react-text-loop](https://www.npmjs.com/package/react-text-loop).

This replaces the antiquated package with the modernized [react-text-loop-next-18](https://www.npmjs.com/package/react-text-loop-next-18) fork.

The fork isn't actively maintained either. Eventually, we want to get rid of the package entirely, but I couldn't find anything else that does the same thing, and we'll be redesigning the website soon enough.