### PR TITLE
partykit: bundle dependencies

### DIFF
--- a/.changeset/short-eagles-yawn.md
+++ b/.changeset/short-eagles-yawn.md
@@ -1,0 +1,12 @@
+---
+"create-partykit": patch
+"partykit": patch
+---
+
+partykit: bundle dependencies
+
+This brings back packaging of dependencies for partykit (and introduces it for create-partykit). We had previously disabled it for deps because of esm/cjs nonsense, but we've now figured out how to make them play decently together.
+
+I had to fork ink-testing-library because of https://github.com/vadimdemedes/ink-testing-library/pull/23, I'll remove it once that PR is merged.
+
+This also updates ink to 4.4.1, which fixes our previous issue where it was exiting early.

--- a/examples/basic/src/server.ts
+++ b/examples/basic/src/server.ts
@@ -13,8 +13,9 @@ export default {
     console.log(SOME_GLOBAL);
     // your business logic here
     ws.addEventListener("message", (evt) => {
+      const connections = [...room.getConnections()];
       if (evt.data === "ping") {
-        ws.send(`pong:${room.connections.size}`);
+        ws.send(`pong:${connections.length}`);
       } else if ((evt.data as string).startsWith("latency")) {
         ws.send(evt.data);
       }
@@ -45,10 +46,10 @@ export default {
     console.log(room.env);
 
     console.log(process.env.WHATUP);
-    console.log(room.parties);
-    const res = await room.parties.xyz.get("some-id").fetch();
+    console.log(room.context.parties);
+    const res = await room.context.parties.xyz.get("some-id").fetch();
     console.log("gottt", await res.text());
-    const wssss = room.parties.xyz.get("some-id").connect();
+    const wssss = room.context.parties.xyz.get("some-id").connect();
     wssss.addEventListener("message", (evt) => {
       console.log("got a message from xyz", evt.data);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,9 +241,10 @@
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.2.tgz",
-      "integrity": "sha512-/9Wcb0XV6jhvbn0UsL0CPBYKRWjSN0Er2vrrhFDNy0IMIvZ7pWBLwOZbFKTlyYCr1Q+UBXb1hWM4czT2FOfT+A==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+      "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "is-fullwidth-code-point": "^4.0.0"
@@ -3475,6 +3476,7 @@
       "version": "1.25.0",
       "resolved": "https://registry.npmjs.org/@clerk/localizations/-/localizations-1.25.0.tgz",
       "integrity": "sha512-D0rfAP/tl46i6jz6VgizvKlF8xSUJJ+ZWyec88rPTd8yylOSZXxIQUHgaXp8gTgXJtTz84rTyZyFpBJN+vqWcQ==",
+      "dev": true,
       "dependencies": {
         "@clerk/types": "^3.50.0"
       },
@@ -3489,6 +3491,7 @@
       "version": "3.50.0",
       "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.50.0.tgz",
       "integrity": "sha512-3TWalDWPTFToXC/W07QUIBN96TA+4dR3YLBvwr9U2Z4RVG9in9HW4CTC6aHTnJ2kVtTcgDkXjDKeVKS1GjPCcA==",
+      "dev": true,
       "dependencies": {
         "csstype": "3.1.1"
       },
@@ -3499,7 +3502,8 @@
     "node_modules/@clerk/types/node_modules/csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "dev": true
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
       "version": "1.20230814.1",
@@ -5459,6 +5463,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
       "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true,
       "engines": {
         "node": ">=12.22.0"
       }
@@ -5467,6 +5472,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
       "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "4.2.10"
       },
@@ -5477,12 +5483,14 @@
     "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "node_modules/@pnpm/npm-conf": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
       "integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+      "dev": true,
       "dependencies": {
         "@pnpm/config.env-replace": "^1.1.0",
         "@pnpm/network.ca-file": "^1.0.1",
@@ -7932,7 +7940,8 @@
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
+      "dev": true
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.1",
@@ -8197,7 +8206,8 @@
     "node_modules/@types/tinycolor2": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.3.tgz",
-      "integrity": "sha512-Kf1w9NE5HEgGxCRyIcRXR/ZYtDv0V8FVPtYHwLxl0O+maGX0erE77pQlD0gpP+/KByMZ87mOA79SjifhSB3PjQ=="
+      "integrity": "sha512-Kf1w9NE5HEgGxCRyIcRXR/ZYtDv0V8FVPtYHwLxl0O+maGX0erE77pQlD0gpP+/KByMZ87mOA79SjifhSB3PjQ==",
+      "dev": true
     },
     "node_modules/@types/trouter": {
       "version": "3.1.1",
@@ -9341,6 +9351,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@zxcvbn-ts/core/-/core-2.2.1.tgz",
       "integrity": "sha512-Cg1JyRpCDIF+Dh3nauqygmmCYxogNVZDxSn+9PgkPD1HZ2QiJe4elruVJrGmYRS7muGmZ1hNJq8ySQdPv6GHaw==",
+      "dev": true,
       "dependencies": {
         "fastest-levenshtein": "1.0.16"
       }
@@ -9348,7 +9359,8 @@
     "node_modules/@zxcvbn-ts/language-common": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@zxcvbn-ts/language-common/-/language-common-3.0.2.tgz",
-      "integrity": "sha512-GPnf4cuSUZXhx3spjRQLtUoI6/+00f9198gcG8hJDBFR4KYfMvLorAk97MU7qeTkyhzhYLR7yLr/E66vH7ZOaw=="
+      "integrity": "sha512-GPnf4cuSUZXhx3spjRQLtUoI6/+00f9198gcG8hJDBFR4KYfMvLorAk97MU7qeTkyhzhYLR7yLr/E66vH7ZOaw==",
+      "dev": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -9500,6 +9512,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
       "integrity": "sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^3.0.0"
       },
@@ -9514,6 +9527,7 @@
       "version": "3.11.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.11.1.tgz",
       "integrity": "sha512-aCuRNRERRVh33lgQaJRlUxZqzfhzwTrsE98Mc3o3VXqmiaQdHacgUtJ0esp+7MvZ92qhtzKPeusaX6vIEcoreA==",
+      "dev": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -9571,6 +9585,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
       "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9635,6 +9650,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/arr-rotate/-/arr-rotate-1.0.0.tgz",
       "integrity": "sha512-yOzOZcR9Tn7enTF66bqKorGGH0F36vcPaSWg8fO0c0UYb3LX3VMXj5ZxEqQLNOecAhlRJ7wYZja5i4jTlnbIfQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -10756,6 +10772,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -11100,12 +11117,14 @@
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "dev": true
     },
     "node_modules/boxen": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
       "integrity": "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==",
+      "dev": true,
       "dependencies": {
         "ansi-align": "^3.0.1",
         "camelcase": "^7.0.1",
@@ -11166,6 +11185,7 @@
       "version": "1.2.15",
       "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.2.15.tgz",
       "integrity": "sha512-J8K9vdivK0Di+b8SBdE7EZxDr88TnATing7XoLw6+nFkXMQ6sVBh92K3NQvZlZU91AIkFRi0w3sztk5Z+vsswA==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "lodash": ">=4.17.21"
@@ -11450,6 +11470,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
       "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "dev": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -11527,6 +11548,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
       "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "dev": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -11880,6 +11902,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
       "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+      "dev": true,
       "dependencies": {
         "slice-ansi": "^5.0.0",
         "string-width": "^5.0.0"
@@ -11895,6 +11918,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
       "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.0.0",
         "is-fullwidth-code-point": "^4.0.0"
@@ -11919,6 +11943,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
       "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+      "dev": true,
       "dependencies": {
         "arch": "^2.2.0",
         "execa": "^5.1.1",
@@ -11935,6 +11960,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -11957,6 +11983,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
       "engines": {
         "node": ">=10.17.0"
       }
@@ -11965,6 +11992,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -11976,6 +12004,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11984,6 +12013,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -11995,6 +12025,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -12009,6 +12040,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -12126,6 +12158,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
       "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "dev": true,
       "dependencies": {
         "convert-to-spaces": "^2.0.1"
       },
@@ -12221,6 +12254,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
       "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "dev": true,
       "engines": {
         "node": ">=16"
       }
@@ -12410,6 +12444,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
       "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
       "dependencies": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -12419,6 +12454,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-6.0.0.tgz",
       "integrity": "sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==",
+      "dev": true,
       "dependencies": {
         "dot-prop": "^6.0.1",
         "graceful-fs": "^4.2.6",
@@ -12468,6 +12504,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -12490,6 +12527,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
       "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dev": true,
       "dependencies": {
         "toggle-selection": "^1.0.6"
       }
@@ -12498,6 +12536,7 @@
       "version": "3.26.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
       "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==",
+      "dev": true,
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -12581,6 +12620,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
       "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^1.0.1"
       },
@@ -12595,6 +12635,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -13342,6 +13383,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
       "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -13571,6 +13613,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
       "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "dev": true,
       "dependencies": {
         "is-obj": "^2.0.0"
       },
@@ -14028,6 +14071,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
       "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -15272,6 +15316,7 @@
       "version": "2.7.13",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.13.tgz",
       "integrity": "sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==",
+      "dev": true,
       "dependencies": {
         "ajv": "^6.11.0",
         "deepmerge": "^4.2.2",
@@ -15291,6 +15336,7 @@
       "version": "1.6.9",
       "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.9.tgz",
       "integrity": "sha512-FChq8hbz65WMj4rstcQsFB0O7Cy++nmbNfLYnD9cYv2cRn8EG6k/MGn9kO/tjO66t09DLDugj3yL+V2o6Qftrg==",
+      "dev": true,
       "dependencies": {
         "boolean": "^3.1.4"
       },
@@ -15323,6 +15369,7 @@
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -15362,6 +15409,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
       "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^5.0.0",
         "is-unicode-supported": "^1.2.0"
@@ -15377,6 +15425,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -15550,6 +15599,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
       "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true,
       "engines": {
         "node": ">= 14.17"
       }
@@ -15627,9 +15677,9 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -15808,6 +15858,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.0.0.tgz",
       "integrity": "sha512-mDHFgApoQd+azgMdwylJrv2DX47ywGq1i5VFJE7fZ0dttNq3iQMfsU4IvEgBHojA3KqEudyu7Vq+oN8kNaNkWw==",
+      "dev": true,
       "engines": {
         "node": ">=16"
       },
@@ -15975,6 +16026,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
       "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+      "dev": true,
       "dependencies": {
         "ini": "2.0.0"
       },
@@ -15989,6 +16041,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -16103,6 +16156,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/gradient-string/-/gradient-string-2.0.2.tgz",
       "integrity": "sha512-rEDCuqUQ4tbD78TpzsMtt5OIf0cBCSDWSJtUDaF6JsAh+k0v9r++NzxNEG87oDZx9ZwGhD8DaezR2L/yrw0Jdw==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
         "tinygradient": "^1.1.5"
@@ -16115,6 +16169,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -16129,6 +16184,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -16144,6 +16200,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -16154,12 +16211,14 @@
     "node_modules/gradient-string/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/gradient-string/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -16374,6 +16433,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-3.0.0.tgz",
       "integrity": "sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -16897,6 +16957,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/http-terminator/-/http-terminator-3.2.0.tgz",
       "integrity": "sha512-JLjck1EzPaWjsmIf8bziM3p9fgR1Y3JoUKAkyYEbZmFrIvJM6I8vVJfBGWlEtV9IWOvzNnaTtjuwZeBY2kwB4g==",
+      "dev": true,
       "dependencies": {
         "delay": "^5.0.0",
         "p-wait-for": "^3.2.0",
@@ -16911,6 +16972,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
       "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
+      "dev": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -16923,6 +16985,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -17032,6 +17095,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
       "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -17057,6 +17121,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -17090,11 +17155,12 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/ink": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ink/-/ink-4.3.1.tgz",
-      "integrity": "sha512-XlH5AiZRLIC4cF+eMgZLsB/feHCDT7lUtHXK4pe8ULGrC6mNosrYidzJr8CRY0P+hK7UmZ1rLO+ufdox53+NQg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-4.4.1.tgz",
+      "integrity": "sha512-rXckvqPBB0Krifk5rn/5LvQGmyXwCUpBfmTwbkQNBY9JY8RSl3b8OftBNEYxg4+SWUhEKcPifgope28uL9inlA==",
+      "dev": true,
       "dependencies": {
-        "@alcalzone/ansi-tokenize": "^0.1.2",
+        "@alcalzone/ansi-tokenize": "^0.1.3",
         "ansi-escapes": "^6.0.0",
         "auto-bind": "^5.0.1",
         "chalk": "^5.2.0",
@@ -17141,6 +17207,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ink-select-input/-/ink-select-input-5.0.0.tgz",
       "integrity": "sha512-VkLEogN3KTgAc0W/u9xK3+44x8JyKfmBvPQyvniJ/Hj0ftg9vWa/YecvZirevNv2SAvgoA2GIlTLCQouzgPKDg==",
+      "dev": true,
       "dependencies": {
         "arr-rotate": "^1.0.0",
         "figures": "^5.0.0",
@@ -17174,6 +17241,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-5.0.1.tgz",
       "integrity": "sha512-crnsYJalG4EhneOFnr/q+Kzw1RgmXI2KsBaLFE6mpiIKxAtJLUnvygOF2IUKO8z4nwkSkveGRBMd81RoYdRSag==",
+      "dev": true,
       "dependencies": {
         "chalk": "^5.2.0",
         "type-fest": "^3.6.1"
@@ -17190,6 +17258,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
       "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -17201,6 +17270,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
       "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -17745,6 +17815,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -17831,6 +17902,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
       "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
       "dependencies": {
         "global-dirs": "^3.0.0",
         "is-path-inside": "^3.0.2"
@@ -17855,6 +17927,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
       "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -17883,6 +17956,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.0.0.tgz",
       "integrity": "sha512-JEjxbSmtPSt1c8XTkVrlujcXdKV1/tvuQ7GwKcAlyiVLeYFQ2VHat8xfrDJsIkhCdF/tZ7CiIR3sy141c6+gPQ==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -17916,6 +17990,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -18091,7 +18166,8 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true
     },
     "node_modules/is-unicode-supported": {
       "version": "1.3.0",
@@ -18108,6 +18184,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
       "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -18186,6 +18263,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.4.1.tgz",
       "integrity": "sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -18319,6 +18397,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
       "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -18494,6 +18573,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-7.0.0.tgz",
       "integrity": "sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==",
+      "dev": true,
       "dependencies": {
         "package-json": "^8.1.0"
       },
@@ -18508,6 +18588,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
       "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+      "dev": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -18519,6 +18600,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
       "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+      "dev": true,
       "dependencies": {
         "defer-to-connect": "^2.0.1"
       },
@@ -18530,6 +18612,7 @@
       "version": "10.2.13",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.13.tgz",
       "integrity": "sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==",
+      "dev": true,
       "dependencies": {
         "@types/http-cache-semantics": "^4.0.1",
         "get-stream": "^6.0.1",
@@ -18547,6 +18630,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -18561,6 +18645,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -18572,6 +18657,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -18580,6 +18666,7 @@
       "version": "12.6.1",
       "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
       "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+      "dev": true,
       "dependencies": {
         "@sindresorhus/is": "^5.2.0",
         "@szmarczak/http-timer": "^5.0.1",
@@ -18603,12 +18690,14 @@
     "node_modules/latest-version/node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
     },
     "node_modules/latest-version/node_modules/keyv": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
       "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -18617,6 +18706,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
       "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -18628,6 +18718,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -18639,6 +18730,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
       "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+      "dev": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -18650,6 +18742,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
       "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+      "dev": true,
       "engines": {
         "node": ">=12.20"
       }
@@ -18658,6 +18751,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.1.tgz",
       "integrity": "sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==",
+      "dev": true,
       "dependencies": {
         "got": "^12.1.0",
         "registry-auth-token": "^5.0.1",
@@ -18675,6 +18769,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
       "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
+      "dev": true,
       "dependencies": {
         "@pnpm/npm-conf": "^2.1.0"
       },
@@ -18686,6 +18781,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
       "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+      "dev": true,
       "dependencies": {
         "rc": "1.2.8"
       },
@@ -18700,6 +18796,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
       "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+      "dev": true,
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
@@ -18714,6 +18811,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -19100,7 +19198,8 @@
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -21575,6 +21674,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -21616,6 +21716,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -21635,6 +21736,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.2.0.tgz",
       "integrity": "sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==",
+      "dev": true,
       "dependencies": {
         "p-timeout": "^3.0.0"
       },
@@ -21950,6 +22052,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -23871,7 +23974,8 @@
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -24022,6 +24126,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
       "integrity": "sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==",
+      "dev": true,
       "dependencies": {
         "escape-goat": "^4.0.0"
       },
@@ -24036,6 +24141,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.1.0.tgz",
       "integrity": "sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==",
+      "dev": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -24044,6 +24150,7 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
       "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -24121,6 +24228,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/random-words/-/random-words-2.0.0.tgz",
       "integrity": "sha512-uqpnDqFnYrZajgmvgjmBrSZL2V1UA/9bNPGrilo12CmBeBszoff/avElutUlwWxG12gvmCk/8dUhvHefYxzYjw==",
+      "dev": true,
       "dependencies": {
         "seedrandom": "^3.0.5"
       }
@@ -24198,6 +24306,7 @@
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.11.tgz",
       "integrity": "sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -24235,6 +24344,7 @@
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.0.tgz",
       "integrity": "sha512-wa0fGj7Zht1EYMRhKWwoo1H9GApxYLBuhoAuXN0TlltESAjDssB+Apf0T/DngVqaMyPypDmabL37vw/2aRM98Q==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -25049,7 +25159,8 @@
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -25193,7 +25304,8 @@
     "node_modules/rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
     },
     "node_modules/rgb-regex": {
       "version": "1.0.1",
@@ -25225,6 +25337,7 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-7.15.0.tgz",
       "integrity": "sha512-CV9WefQfUXTX6wr8CrEMhfNef3sjIt9wNhE/5PNu4tNWsaoDNDXqq+OGn/RW9A1UPb0qc7FQlswXRaJJJsqn8A==",
+      "dev": true,
       "dependencies": {
         "boolean": "^3.1.4",
         "fast-json-stringify": "^2.7.10",
@@ -25484,6 +25597,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
       "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -25564,7 +25678,8 @@
     "node_modules/seedrandom": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "dev": true
     },
     "node_modules/sembear": {
       "version": "0.5.2",
@@ -25594,12 +25709,14 @@
     "node_modules/semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true
     },
     "node_modules/semver-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
       "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
+      "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -25614,6 +25731,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -26016,6 +26134,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-6.0.0.tgz",
       "integrity": "sha512-6bn4hRfkTvDfUoEQYkERg0BVF1D0vrX9HEkMl08uDiNWvVvjylLHvZFZWkDo6wjT8tUctbYl1nCOuE66ZTaUtA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "is-fullwidth-code-point": "^4.0.0"
@@ -26458,6 +26577,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -26469,6 +26589,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -26627,7 +26748,8 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
       "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -27392,12 +27514,14 @@
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "dev": true
     },
     "node_modules/tinygradient": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-1.1.5.tgz",
       "integrity": "sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==",
+      "dev": true,
       "dependencies": {
         "@types/tinycolor2": "^1.4.0",
         "tinycolor2": "^1.0.0"
@@ -27479,7 +27603,8 @@
     "node_modules/toggle-selection": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "dev": true
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -28128,6 +28253,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -28293,6 +28419,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
       "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
       "dependencies": {
         "crypto-random-string": "^4.0.0"
       },
@@ -28523,6 +28650,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-6.0.2.tgz",
       "integrity": "sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==",
+      "dev": true,
       "dependencies": {
         "boxen": "^7.0.0",
         "chalk": "^5.0.1",
@@ -28550,6 +28678,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -29341,6 +29470,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "is-typedarray": "^1.0.0",
@@ -29378,6 +29508,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
       "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -29904,17 +30035,7 @@
       "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
-        "chalk": "^5.3.0",
-        "commander": "^11.0.0",
-        "execa": "^7.2.0",
-        "find-up": "^6.3.0",
-        "gradient-string": "^2.0.2",
-        "ink": "4.3.1",
-        "ink-select-input": "^5.0.0",
-        "ink-text-input": "^5.0.1",
-        "random-words": "^2.0.0",
-        "react": "^18.2.0",
-        "which-pm-runs": "^1.1.0"
+        "yoga-wasm-web": "^0.3.3"
       },
       "bin": {
         "create-partykit": "dist/index.mjs"
@@ -29924,8 +30045,22 @@
         "@types/random-words": "^1.1.2",
         "@types/react": "^18.2.20",
         "@types/which-pm-runs": "^1.0.0",
+        "chalk": "^5.3.0",
+        "commander": "^11.0.0",
         "esbuild": "^0.19.2",
-        "typescript": "^5.1.6"
+        "execa": "^7.2.0",
+        "find-up": "^6.3.0",
+        "gradient-string": "^2.0.2",
+        "ink": "4.4.1",
+        "ink-select-input": "^5.0.0",
+        "ink-text-input": "^5.0.1",
+        "random-words": "^2.0.0",
+        "react": "^18.2.0",
+        "typescript": "^5.1.6",
+        "which-pm-runs": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
       }
     },
     "packages/create-partykit/node_modules/@esbuild/android-arm": {
@@ -30321,6 +30456,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
       "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^7.1.0",
         "path-exists": "^5.0.0"
@@ -30336,6 +30472,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
       "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^6.0.0"
       },
@@ -30350,6 +30487,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
       "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -30364,6 +30502,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
       "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^4.0.0"
       },
@@ -30378,6 +30517,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
       "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -30385,24 +30525,42 @@
     "packages/partykit": {
       "version": "0.0.9",
       "dependencies": {
-        "@clerk/clerk-js": "4.55.0",
         "@cloudflare/workers-types": "^4.20230814.0",
+        "esbuild": "^0.19.2",
+        "miniflare": "^3.20230814.1",
+        "yoga-wasm-web": "^0.3.3"
+      },
+      "bin": {
+        "partykit": "dist/bin.mjs"
+      },
+      "devDependencies": {
+        "@clerk/clerk-js": "4.55.0",
+        "@types/execa": "^2.0.0",
+        "@types/gradient-string": "^1.1.2",
+        "@types/mime": "^3.0.1",
+        "@types/node": "^20.5.0",
+        "@types/object-hash": "^3.0.3",
+        "@types/polka": "^0.5.4",
+        "@types/prompts": "^2.4.4",
+        "@types/update-notifier": "^6.0.4",
+        "@types/ws": "^8.5.5",
         "chalk": "^5.3.0",
         "chokidar": "^3.5.3",
         "clipboardy": "^3.0.0",
         "commander": "^11.0.0",
+        "devtools-protocol": "^0.0.1182435",
         "dotenv": "^16.3.1",
-        "esbuild": "^0.19.2",
+        "dotenv-cli": "^7.3.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "execa": "^7.2.0",
         "find-up": "^6.3.0",
         "get-port": "^7.0.0",
         "gradient-string": "^2.0.2",
         "http-terminator": "^3.2.0",
-        "ink": "4.3.1",
+        "ink": "4.4.1",
         "ink-select-input": "^5.0.0",
         "json5": "^2.2.3",
         "mime": "^3.0.0",
-        "miniflare": "^3.20230814.1",
         "object-hash": "^3.0.0",
         "open": "^9.1.0",
         "prompts": "^2.4.2",
@@ -30414,25 +30572,11 @@
         "update-notifier": "^6.0.2",
         "which-pm-runs": "^1.1.0",
         "ws": "^8.13.0",
-        "zod": "^3.22.1"
-      },
-      "bin": {
-        "partykit": "dist/bin.mjs"
-      },
-      "devDependencies": {
-        "@types/execa": "^2.0.0",
-        "@types/gradient-string": "^1.1.2",
-        "@types/mime": "^3.0.1",
-        "@types/node": "^20.5.0",
-        "@types/object-hash": "^3.0.3",
-        "@types/polka": "^0.5.4",
-        "@types/prompts": "^2.4.4",
-        "@types/update-notifier": "^6.0.4",
-        "@types/ws": "^8.5.5",
-        "devtools-protocol": "^0.0.1182435",
-        "dotenv-cli": "^7.3.0",
-        "eslint-plugin-react-hooks": "^4.6.0",
+        "zod": "^3.22.1",
         "zod-to-json-schema": "^3.21.4"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
       }
     },
     "packages/partykit.io": {
@@ -30443,6 +30587,7 @@
       "version": "4.55.0",
       "resolved": "https://registry.npmjs.org/@clerk/clerk-js/-/clerk-js-4.55.0.tgz",
       "integrity": "sha512-mhVape/9fcUU8z3CY/iduzROQ4reai0el+DZQ2meDIZO/vYk7Ya5CRFrFEt5iS7zF5998wnfQE6WCcRVPNc11g==",
+      "dev": true,
       "dependencies": {
         "@clerk/localizations": "^1.24.1",
         "@clerk/shared": "^0.21.0",
@@ -30468,6 +30613,7 @@
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-0.21.0.tgz",
       "integrity": "sha512-tkV2OAddFMPBHDjcMbtNNrV3NQD+hGKf2hn3TKv1mRJNZ2oR5Bfk8r0bkaqwoqxX8ndkbHLCa9gwR8SWO7GGow==",
+      "dev": true,
       "dependencies": {
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.1",
@@ -30481,6 +30627,7 @@
       "version": "11.10.5",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
       "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
+      "dev": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.0",
         "@emotion/sheet": "^1.2.1",
@@ -30493,6 +30640,7 @@
       "version": "11.10.5",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.5.tgz",
       "integrity": "sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.10.5",
@@ -30850,6 +30998,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.19.0.tgz",
       "integrity": "sha512-fgYvN4ksCi5OvmPXkyOT8o5a8PSKHMzPHt+9mR6KYWdF16IAjWRLZPAAziI2sznaWT23drRFrYw64wdvYqqaQw==",
+      "dev": true,
       "dependencies": {
         "@floating-ui/react-dom": "^1.2.2",
         "aria-hidden": "^1.1.3",
@@ -30870,6 +31019,7 @@
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
       "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -30917,6 +31067,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
       "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^7.1.0",
         "path-exists": "^5.0.0"
@@ -30932,6 +31083,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
       "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^6.0.0"
       },
@@ -30946,6 +31098,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
       "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -30960,6 +31113,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
       "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^4.0.0"
       },
@@ -30974,6 +31128,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
       "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -30982,6 +31137,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -30992,12 +31148,14 @@
     "packages/partykit/node_modules/stylis": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
-      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==",
+      "dev": true
     },
     "packages/partykit/node_modules/swr": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
       "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==",
+      "dev": true,
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
       }

--- a/packages/create-partykit/package.json
+++ b/packages/create-partykit/package.json
@@ -11,30 +11,35 @@
   "files": [
     "dist",
     "js-template",
-    "ts-template"
+    "ts-template",
+    "rdt-mock.js"
   ],
   "keywords": [],
   "author": "PartyKit, Inc. <team@partykit.io>",
   "license": "ISC",
   "dependencies": {
-    "chalk": "^5.3.0",
-    "commander": "^11.0.0",
-    "execa": "^7.2.0",
-    "find-up": "^6.3.0",
-    "gradient-string": "^2.0.2",
-    "ink": "4.3.1",
-    "ink-select-input": "^5.0.0",
-    "ink-text-input": "^5.0.1",
-    "random-words": "^2.0.0",
-    "react": "^18.2.0",
-    "which-pm-runs": "^1.1.0"
+    "yoga-wasm-web": "^0.3.3"
+  },
+  "optionalDependencies": {
+    "fsevents": "^2.3.3"
   },
   "devDependencies": {
     "@types/execa": "^2.0.0",
     "@types/random-words": "^1.1.2",
     "@types/react": "^18.2.20",
     "@types/which-pm-runs": "^1.0.0",
+    "chalk": "^5.3.0",
+    "commander": "^11.0.0",
     "esbuild": "^0.19.2",
-    "typescript": "^5.1.6"
+    "execa": "^7.2.0",
+    "find-up": "^6.3.0",
+    "gradient-string": "^2.0.2",
+    "ink": "4.4.1",
+    "ink-select-input": "^5.0.0",
+    "ink-text-input": "^5.0.1",
+    "random-words": "^2.0.0",
+    "react": "^18.2.0",
+    "typescript": "^5.1.6",
+    "which-pm-runs": "^1.1.0"
   }
 }

--- a/packages/create-partykit/rdt-mock.js
+++ b/packages/create-partykit/rdt-mock.js
@@ -1,0 +1,5 @@
+// we don't want to bundle react-devtools-core
+// but there's an import in ink we want to mock
+// hence this file, included by scripts/build.ts
+
+export default {};

--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -12,24 +12,42 @@
     "./src/cli": "./src/cli.ts"
   },
   "dependencies": {
-    "@clerk/clerk-js": "4.55.0",
     "@cloudflare/workers-types": "^4.20230814.0",
+    "esbuild": "^0.19.2",
+    "miniflare": "^3.20230814.1",
+    "yoga-wasm-web": "^0.3.3"
+  },
+  "optionalDependencies": {
+    "fsevents": "^2.3.3"
+  },
+  "devDependencies": {
+    "@clerk/clerk-js": "4.55.0",
+    "@types/execa": "^2.0.0",
+    "@types/gradient-string": "^1.1.2",
+    "@types/mime": "^3.0.1",
+    "@types/node": "^20.5.0",
+    "@types/object-hash": "^3.0.3",
+    "@types/polka": "^0.5.4",
+    "@types/prompts": "^2.4.4",
+    "@types/update-notifier": "^6.0.4",
+    "@types/ws": "^8.5.5",
     "chalk": "^5.3.0",
     "chokidar": "^3.5.3",
     "clipboardy": "^3.0.0",
     "commander": "^11.0.0",
+    "devtools-protocol": "^0.0.1182435",
     "dotenv": "^16.3.1",
-    "esbuild": "^0.19.2",
+    "dotenv-cli": "^7.3.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "execa": "^7.2.0",
     "find-up": "^6.3.0",
     "get-port": "^7.0.0",
     "gradient-string": "^2.0.2",
     "http-terminator": "^3.2.0",
-    "ink": "4.3.1",
+    "ink": "4.4.1",
     "ink-select-input": "^5.0.0",
     "json5": "^2.2.3",
     "mime": "^3.0.0",
-    "miniflare": "^3.20230814.1",
     "object-hash": "^3.0.0",
     "open": "^9.1.0",
     "prompts": "^2.4.2",
@@ -41,21 +59,7 @@
     "update-notifier": "^6.0.2",
     "which-pm-runs": "^1.1.0",
     "ws": "^8.13.0",
-    "zod": "^3.22.1"
-  },
-  "devDependencies": {
-    "@types/execa": "^2.0.0",
-    "@types/gradient-string": "^1.1.2",
-    "@types/mime": "^3.0.1",
-    "@types/node": "^20.5.0",
-    "@types/object-hash": "^3.0.3",
-    "@types/polka": "^0.5.4",
-    "@types/prompts": "^2.4.4",
-    "@types/update-notifier": "^6.0.4",
-    "@types/ws": "^8.5.5",
-    "devtools-protocol": "^0.0.1182435",
-    "dotenv-cli": "^7.3.0",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "zod": "^3.22.1",
     "zod-to-json-schema": "^3.21.4"
   },
   "files": [
@@ -64,7 +68,8 @@
     "*.d.ts.map",
     "facade/generated.js",
     "schema.json",
-    "init"
+    "init",
+    "rdt-mock.js"
   ],
   "scripts": {
     "clean": "shx rm -rf dist dts *.d.ts *.d.ts.map && mkdir dts",

--- a/packages/partykit/rdt-mock.js
+++ b/packages/partykit/rdt-mock.js
@@ -1,0 +1,5 @@
+// we don't want to bundle react-devtools-core
+// but there's an import in ink we want to mock
+// hence this file, included by scripts/build.ts
+
+export default {};

--- a/packages/partykit/src/tests/dev.test.tsx
+++ b/packages/partykit/src/tests/dev.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { render } from "ink-testing-library";
+import { render } from "./ink-testing-library";
 import type { DevProps } from "../dev";
 import { Dev } from "../dev";
 import { fetch } from "undici";

--- a/packages/partykit/src/tests/ink-testing-library.ts
+++ b/packages/partykit/src/tests/ink-testing-library.ts
@@ -1,0 +1,118 @@
+// This is a fork of ink-testing-library
+// until https://github.com/vadimdemedes/ink-testing-library/pull/23 is merged
+
+import { EventEmitter } from "node:events";
+import { render as inkRender } from "ink";
+import type { Instance as InkInstance } from "ink";
+import type { ReactElement } from "react";
+
+class Stdout extends EventEmitter {
+  get columns() {
+    return 100;
+  }
+
+  readonly frames: string[] = [];
+  private _lastFrame?: string;
+
+  write = (frame: string) => {
+    this.frames.push(frame);
+    this._lastFrame = frame;
+  };
+
+  lastFrame = () => this._lastFrame;
+}
+
+class Stderr extends EventEmitter {
+  readonly frames: string[] = [];
+  private _lastFrame?: string;
+
+  write = (frame: string) => {
+    this.frames.push(frame);
+    this._lastFrame = frame;
+  };
+
+  lastFrame = () => this._lastFrame;
+}
+
+class Stdin extends EventEmitter {
+  isTTY = true;
+
+  write = (data: string) => {
+    this.emit("data", data);
+  };
+
+  setEncoding() {
+    // Do nothing
+  }
+
+  setRawMode() {
+    // Do nothing
+  }
+
+  resume() {
+    // Do nothing
+  }
+
+  pause() {
+    // Do nothing
+  }
+
+  ref() {
+    // Do nothing
+  }
+
+  unref() {
+    // Do nothing
+  }
+}
+
+type Instance = {
+  rerender: (tree: ReactElement) => void;
+  unmount: () => void;
+  cleanup: () => void;
+  stdout: Stdout;
+  stderr: Stderr;
+  stdin: Stdin;
+  frames: string[];
+  lastFrame: () => string | undefined;
+};
+
+const instances: InkInstance[] = [];
+
+export const render = (tree: ReactElement): Instance => {
+  const stdout = new Stdout();
+  const stderr = new Stderr();
+  const stdin = new Stdin();
+
+  const instance = inkRender(tree, {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stdout: stdout as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stderr: stderr as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stdin: stdin as any,
+    debug: true,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+
+  instances.push(instance);
+
+  return {
+    rerender: instance.rerender,
+    unmount: instance.unmount,
+    cleanup: instance.cleanup,
+    stdout,
+    stderr,
+    stdin,
+    frames: stdout.frames,
+    lastFrame: stdout.lastFrame,
+  };
+};
+
+export const cleanup = () => {
+  for (const instance of instances) {
+    instance.unmount();
+    instance.cleanup();
+  }
+};


### PR DESCRIPTION
This brings back packaging of dependencies for partykit (and introduces it for create-partykit). We had previously disabled it for deps because of esm/cjs nonsense, but we've now figured out how to make them play decently together.

I had to fork ink-testing-library because of https://github.com/vadimdemedes/ink-testing-library/pull/23, I'll remove it once that PR is merged.

This also updates ink to 4.4.1, which fixes our previous issue where it was exiting early.