### PR TITLE
Use bun install in CI

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,15 +21,11 @@ jobs:
           node-version: 18
           cache: "npm"
 
-      - uses: actions/cache@v3
-        id: check-cache
+      - uses: oven-sh/setup-bun@v1
         with:
-          path: |
-            .eslintcache
-            **/*/tsconfig.tsbuildinfo
-          key: eslint-tsbuildinfo-${{ hashFiles('**/*.ts','**/*.js', 'package-lock.json', 'tsconfig.json', '**/*/tsconfig.json', '.eslintrc.js') }}
+          bun-version: latest
 
-      - run: npm ci
+      - run: bun install
 
       - name: Modify package.json version
         run: node .github/version-script.js

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -23,15 +23,11 @@ jobs:
           node-version: 18
           cache: "npm"
 
-      - uses: actions/cache@v3
-        id: check-cache
+      - uses: oven-sh/setup-bun@v1
         with:
-          path: |
-            .eslintcache
-            **/*/tsconfig.tsbuildinfo
-          key: eslint-tsbuildinfo-${{ hashFiles('**/*.ts','**/*.js', 'package-lock.json', 'tsconfig.json', '**/*/tsconfig.json', '.eslintrc.js') }}
+          bun-version: latest
 
-      - run: npm ci
+      - run: bun install
 
       - run: npm run build
       - run: npm run check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,11 @@ jobs:
           node-version: 18
           cache: "npm"
 
-      - uses: actions/cache@v3
-        id: check-cache
+      - uses: oven-sh/setup-bun@v1
         with:
-          path: |
-            .eslintcache
-            **/*/tsconfig.tsbuildinfo
-          key: eslint-tsbuildinfo-${{ hashFiles('**/*.ts','**/*.js', 'package-lock.json', 'tsconfig.json', '**/*/tsconfig.json', '.eslintrc.js') }}
+          bun-version: latest
 
-      - run: npm ci
+      - run: bun install
 
       - run: npm run build
       - run: npm run check

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "tsup": "^7.2.0",
     "typescript": "^5.1.6",
     "vitest": "^0.34.1"
-  }
+  },
+  "trustedDependencies": [
+    "sharp"
+  ]
 }


### PR DESCRIPTION
This patch replaces the caching and npm ci steps with a plain bun install in CI for all workflows. It appears to consistently shave off about a minute, pretty good.