### PR TITLE
Change serveSinglePageApp to singlePageApp in docs

### DIFF
--- a/apps/docs/src/content/docs/guides/serving-static-assets.md
+++ b/apps/docs/src/content/docs/guides/serving-static-assets.md
@@ -36,7 +36,7 @@ While PartyKit defaults should satisfy most needs, you can override some optiona
 
 
     // serve in "single page app" mode
-    serveSinglePageApp: true
+    singlePageApp: true
     // COMING SOON: exclude files from being served
     exclude: ["**/*.map"] // PartyKit already excludes dotfiles and node_modules
     // COMING SOON: include files to be served


### PR DESCRIPTION
As I was working on my PartyKit app, I tried setting the `serveSinglePageApp` setting as it was demonstrated in the docs.

As it turns out, this isn't how the config is implemented in the code though. Setting it to `singlePageApp` worked correctly.

This PR changes the docs to match the correct behavior.