### PR TITLE
Fix `./` paths and other relative paths for create-partykit

### DIFF
--- a/.changeset/strange-carrots-scream.md
+++ b/.changeset/strange-carrots-scream.md
@@ -1,0 +1,5 @@
+---
+"create-partykit": patch
+---
+
+Fix relative paths in create-partykit

--- a/packages/create-partykit/src/index.tsx
+++ b/packages/create-partykit/src/index.tsx
@@ -206,7 +206,7 @@ export async function init(options: {
             `Absolute paths not supported. Please use a relative path like "randomName", "./randomName", or just "." to use the current directory. You entered "${text}"`
           )
         );
-        reject(new Error("Invalid path"));
+        reject(new Error("Absolute paths not supported"));
       }
 
       const parsed = path.parse(text);

--- a/packages/create-partykit/src/index.tsx
+++ b/packages/create-partykit/src/index.tsx
@@ -198,14 +198,26 @@ export async function init(options: {
       return;
     }
 
-    function done(text: string) {
-      // TODO: make sure text is a valid path
-      const isValidPathRegex = /^([a-zA-Z0-9_-]+\/)*[a-zA-Z0-9_-]+$/;
-
-      if (!isValidPathRegex.test(text || randomName)) {
+    function done(input: string) {
+      const text = input || randomName;
+      if (path.isAbsolute(text)) {
         console.log(
           chalk.red(
-            `Invalid path. Please use a path like "randomName" or just "." to use the current directory. You entered "${text}"`
+            `Absolute paths not supported. Please use a relative path like "randomName", "./randomName", or just "." to use the current directory. You entered "${text}"`
+          )
+        );
+        reject(new Error("Invalid path"));
+      }
+
+      const parsed = path.parse(text);
+      const isValidPathRegex = /^\.*?([a-zA-Z0-9_-]{0,}\/)*[a-zA-Z0-9_-]+$/;
+      if (
+        !isValidPathRegex.test(parsed.base) ||
+        !isValidPathRegex.test(parsed.name)
+      ) {
+        console.log(
+          chalk.red(
+            `Invalid path. Please use a valid directory name like "randomName". You entered "${input}"`
           )
         );
         reject(new Error("Invalid path"));

--- a/packages/create-partykit/src/index.tsx
+++ b/packages/create-partykit/src/index.tsx
@@ -249,15 +249,11 @@ export async function init(options: {
   if (!options.dryRun) {
     fs.mkdirSync(pathToProject, { recursive: true });
     process.chdir(pathToProject);
-    console.log(
-      `‣ Creating project at ${chalk.bold(
-        path.relative(originalCwd, pathToProject)
-      )}`
-    );
+    console.log(`‣ Creating project at ${chalk.bold(pathToProject)}`);
   } else {
     console.log(
       `⤬ Dry run: skipping creating project directory at ${chalk.bold(
-        path.relative(originalCwd, pathToProject)
+        pathToProject
       )}`
     );
   }

--- a/packages/create-partykit/src/index.tsx
+++ b/packages/create-partykit/src/index.tsx
@@ -211,10 +211,9 @@ export async function init(options: {
 
       const parsed = path.parse(text);
       const isValidPathRegex = /^\.*?([a-zA-Z0-9_-]{0,}\/)*[a-zA-Z0-9_-]+$/;
-      if (
-        !isValidPathRegex.test(parsed.base) ||
-        !isValidPathRegex.test(parsed.name)
-      ) {
+      const isValidPath = (path: string) =>
+        path === "." || path === ".." || isValidPathRegex.test(path);
+      if (!isValidPath(parsed.base) || !isValidPath(parsed.name)) {
         console.log(
           chalk.red(
             `Invalid path. Please use a valid directory name like "randomName". You entered "${input}"`


### PR DESCRIPTION
Fixes #341 and closes #309. Also expands the legal paths to any relative path from the current working directory.

Valid paths:
```
.
./
../
./hello
../hello
../../hello
hello
hello/world
```

Invalid paths
```
hello world
./hello world
hello.json
/hello

```

As per last invalid path example, we still don't allow absolute paths. We could enable this as well, but it would have required changing the path resolution code elsewhere, and writing to absolute paths is most likely unintended, so I didn't enable it for now.
