### PR TITLE
Only yield open hibernating connections from getConnections()

### DIFF
--- a/.changeset/few-carrots-care.md
+++ b/.changeset/few-carrots-care.md
@@ -1,0 +1,6 @@
+---
+"y-partykit": patch
+"partykit": patch
+---
+
+Only yield open hibernating connections to match non-hibernating behaviour + polyfill WebSocket status code on platform side

--- a/packages/partykit/facade/connection.ts
+++ b/packages/partykit/facade/connection.ts
@@ -3,7 +3,7 @@ import type * as Party from "../src/server";
 // Polyfill WebSocket status code constants for environments that don't have them
 // in order to support libraries that expect standards-compatible WebSocket
 // implementations (e.g. PartySocket)
-if ("OPEN" in WebSocket) {
+if (!("OPEN" in WebSocket)) {
   const WebSocketStatus = {
     CONNECTING: WebSocket.READY_STATE_CONNECTING,
     OPEN: WebSocket.READY_STATE_OPEN,

--- a/packages/y-partykit/src/provider.ts
+++ b/packages/y-partykit/src/provider.ts
@@ -15,20 +15,6 @@ export const messageQueryAwareness = 3;
 export const messageAwareness = 1;
 export const messageAuth = 2;
 
-export const WebSocketStatus = {
-  CONNECTING: 0,
-  OPEN: 1,
-  CLOSING: 2,
-  CLOSED: 3,
-};
-
-// Polyfill WebSocket status code constants for environments that don't have them
-// (e.g. Cloudflare Workers)
-if (WebSocket.OPEN === undefined) {
-  Object.assign(WebSocket, WebSocketStatus);
-  Object.assign(WebSocket.prototype, WebSocketStatus);
-}
-
 // Disable BroadcastChannel by default in Cloudflare Workers / Node
 const DEFAULT_DISABLE_BC = typeof window === "undefined";
 


### PR DESCRIPTION
Discovered a discrepancy between hibernating and non-hibernating socket behaviour: in hibernation mode, the `getConnections()` method returned sockets that were closing or recently closed.

This is in fact [documented behaviour](https://developers.cloudflare.com/durable-objects/api/hibernatable-websockets-api/#state-methods-for-websockets):
> getWebSockets() may still return websockets even after ws.close() has been called. For example, if your server-side WebSocket (the Durable Object) sends a close, but does not receive one back (and has not detected a disconnect from the client), then the connection is in the CLOSING “readyState”. The client might send more messages, so the WebSocket is technically not disconnected.

However, for our use case, we want the behaviour to match the manual connection tracking we do in non-hibernating mode, where connections are added/removed after the connection/disconnection event. This fixes that.

While making this change, I did a bit of housekeeping and moved the WebSocket connection state polyfills to the platform as agreed we should do.

