### PR TITLE
Reduce double ping in client.js/ts

### DIFF
--- a/.changeset/neat-ghosts-cry.md
+++ b/.changeset/neat-ghosts-cry.md
@@ -1,0 +1,7 @@
+---
+"create-partykit": patch
+---
+
+Reduce double ping in client.js/ts
+
+When server hot-reloads (for example), the clients reconnect and another ping sequence starts. You then get multiple pings from each browser. This change cancels an existing sequence if it exists.

--- a/packages/create-partykit/js-template/src/client.js
+++ b/packages/create-partykit/js-template/src/client.js
@@ -5,6 +5,8 @@ import "./styles.css";
 
 import PartySocket from "partysocket";
 
+let pingInterval;
+
 /** @type {HTMLDivElement} - The DOM element to append all messages we get */
 const output = document.getElementById("app");
 
@@ -43,7 +45,8 @@ conn.addEventListener("open", function () {
   add("Sending a ping every 2 seconds...");
 
   // TODO: make this more interesting / nice
-  setInterval(function () {
+  clearInterval(pingInterval);
+  pingInterval = setInterval(function () {
     conn.send("ping");
   }, 1000);
 });

--- a/packages/create-partykit/ts-template/src/client.ts
+++ b/packages/create-partykit/ts-template/src/client.ts
@@ -4,6 +4,8 @@ import PartySocket from "partysocket";
 
 declare const PARTYKIT_HOST: string;
 
+let pingInterval: number;
+
 // Let's append all the messages we get into this DOM element
 const output = document.getElementById("app") as HTMLDivElement;
 
@@ -31,7 +33,8 @@ conn.addEventListener("open", () => {
   add("Connected!");
   add("Sending a ping every 2 seconds...");
   // TODO: make this more interesting / nice
-  setInterval(() => {
+  clearInterval(pingInterval);
+  pingInterval = setInterval(() => {
     conn.send("ping");
   }, 1000);
 });

--- a/packages/create-partykit/ts-template/src/client.ts
+++ b/packages/create-partykit/ts-template/src/client.ts
@@ -4,7 +4,7 @@ import PartySocket from "partysocket";
 
 declare const PARTYKIT_HOST: string;
 
-let pingInterval: number;
+let pingInterval: ReturnType<typeof setInterval>;
 
 // Let's append all the messages we get into this DOM element
 const output = document.getElementById("app") as HTMLDivElement;


### PR DESCRIPTION
When server hot-reloads (for example), the clients reconnect and another ping sequence starts. You then get multiple pings from each browser. This change cancels an existing sequence if it exists.