### PR TITLE
use npm install instead of npm ci

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 18
           cache: "npm"
 
-      - run: npm ci
+      - run: npm install
 
       - name: Modify package.json version
         run: node .github/version-script.js

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 18
           cache: "npm"
 
-      - run: npm ci
+      - run: npm install
 
       - run: npm run build
       - run: npm run check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 18
           cache: "npm"
 
-      - run: npm ci
+      - run: npm install
 
       - run: npm run build
 

--- a/apps/docs/src/content/docs/guides/setting-up-ci-cd-with-github-actions.md
+++ b/apps/docs/src/content/docs/guides/setting-up-ci-cd-with-github-actions.md
@@ -42,7 +42,7 @@ jobs:
         with:
           node-version: 18
           cache: "npm"
-      - run: npm ci
+      - run: npm install
       - run: npx partykit deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
we have a package-lock, so I'm curious whether it affects install times