### PR TITLE
Compress the header horizontally on small screens

### DIFF
--- a/apps/site/src/components/Header.astro
+++ b/apps/site/src/components/Header.astro
@@ -9,10 +9,10 @@ const { title, subtitle, text, variant = 1 } = Astro.props;
 {
   variant === 1 && (
     <header class="gray-0 flex items-center justify-between px3 py1">
-      <a href="/" class="p3 link gray-0 fw6 f-logo">
+      <a href="/" class="py3 pl3 pr2 link gray-0 fw6 f-logo">
         PartyKit
       </a>
-      <nav class="flex g3 p3">
+      <nav class="flex g2 g3-s py3 pr3 pl2">
         <NavLink href="https://docs.partykit.io">
           <span class="fw6">Docs</span>
         </NavLink>

--- a/apps/site/src/components/Hero.astro
+++ b/apps/site/src/components/Hero.astro
@@ -62,7 +62,7 @@ const { title, subtitle, kicker, text, variant = 12} = Astro.props;
         <iframe 
             src='https://multicursor-sketch.vercel.app?host=io' 
             class='bn overflow-hidden w-100 h-100 db' 
-            style='border-right: 1px solid black; opacity: 0.75;'>
+            style='opacity: 0.75;'>
         </iframe>
         </div>
         <h1 class='relative my0 lh-title lh-solid-s f8 f8-s f10-l fw9 tracked-tight mt4'
@@ -92,7 +92,7 @@ const { title, subtitle, kicker, text, variant = 12} = Astro.props;
 }
 {variant === 13 && 
     <header class='px4 py6 py7-m bb'>
-        <div class'mw9 center'>
+        <div class='mw9 center'>
         <h1 class='my0 lh-solid f5 f8-s fw9 tracked-tight mt4'>{title}</h1>
         <p class='lh-copy f5 f5-s mt4 measure'>{text}</p>
         <div class='flex g4'>


### PR DESCRIPTION
There's a bug on mobile where the header can't compress horizontally, and this adds a right-hand margin for the rest of the site. Existing:

![image](https://github.com/partykit/partykit/assets/265390/d62a2189-c700-4e46-99bc-6a5daf3f62ba)

This PR allows the header to shrink down just enough to avoid this happening:

![image](https://github.com/partykit/partykit/assets/265390/ebcf648d-bf72-42ee-9d9e-657e7dcd0cab)

It also removes a rogue right-hand black border on the hero iframe.