### PR TITLE
add `party.name`

### DIFF
--- a/.changeset/witty-eagles-wonder.md
+++ b/.changeset/witty-eagles-wonder.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+add `party.name`
+
+This exposes the parent level name of the party (default "main", other wise the key from `parties` in `partykit.json`

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -118,7 +118,12 @@ function createMultiParties(
   return parties;
 }
 
-function createDurable(Worker: Party.PartyKitServer) {
+function createDurable(
+  Worker: Party.PartyKitServer,
+  options: {
+    name: string;
+  }
+) {
   const isClassAPI = isClassWorker(Worker);
 
   // When the worker is a class, to validate worker shape we'll look onto the worker prototype
@@ -203,6 +208,7 @@ function createDurable(Worker: Party.PartyKitServer) {
           );
         },
         internalID: this.controller.id.toString(),
+        name: options.name,
         env: PARTYKIT_VARS,
         storage: this.controller.storage,
         broadcast: this.broadcast,
@@ -504,7 +510,7 @@ const Workers: Record<string, Party.PartyKitServer> = {
   main: Worker,
 };
 
-export const PartyKitDurable = createDurable(Worker);
+export const PartyKitDurable = createDurable(Worker, { name: "main" });
 __PARTIES__;
 declare const __PARTIES__: Record<string, string>;
 

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -521,7 +521,7 @@ function useDev(options: DevProps): {
                   ([name, party]) =>
                     `
 import ${name} from '${party}'; 
-export const ${name}DO = createDurable(${name});
+export const ${name}DO = createDurable(${name}, { name: "${name}" });
 Workers["${name}"] = ${name};
 `
                 )

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -88,6 +88,9 @@ export type Party = {
   /** Internal ID assigned by the platform. Use Party.id instead. */
   internalID: string;
 
+  /** Party name defined in the Party URL, e.g. /parties/:name/:id */
+  name: string;
+
   /** Environment variables (--var, partykit.json#vars, or .env) */
   env: Record<string, unknown>;
 


### PR DESCRIPTION
This exposes the parent level name of the party (default "main", other wise the key from `parties` in `partykit.json`