### PR TITLE
partysocket fix: don't crash in stackblitz

### DIFF
--- a/.changeset/little-brooms-stare.md
+++ b/.changeset/little-brooms-stare.md
@@ -1,0 +1,9 @@
+---
+"partysocket": patch
+---
+
+partysocket fix: don't crash in codesandbox
+
+looks like tools like stackblitz defines `process` on the fronted (???), but when we test for process.versions.node it crashes. This fixes the detection logic.
+
+(PartyKit doesn't work in stackblitz yet, but atleast this error shouldn't happen)

--- a/packages/partysocket/src/ws.ts
+++ b/packages/partysocket/src/ws.ts
@@ -81,7 +81,7 @@ function cloneEventNode(e: Event) {
 
 const isNode =
   typeof process !== "undefined" &&
-  typeof process.versions.node !== "undefined" &&
+  typeof process.versions?.node !== "undefined" &&
   typeof document === "undefined";
 
 const cloneEvent = isNode ? cloneEventNode : cloneEventBrowser;


### PR DESCRIPTION
looks like tools like stackblitz defines `process` on the fronted (???), but when we test for process.versions.node it crashes. This fixes the detection logic.

(PartyKit doesn't work in stackblitz yet, but atleast this error shouldn't happen)