### PR TITLE
expose `partySocket.name`, and a static `.url`

### DIFF
--- a/.changeset/clever-badgers-sing.md
+++ b/.changeset/clever-badgers-sing.md
@@ -1,0 +1,7 @@
+---
+"partysocket": patch
+---
+
+expose `partySocket.name`, and a static `.url`
+
+This exposes the top level party 'name' on partysocket. Since urls for partysocket are 'static' we can also override the base implementation and expose the calculated url as well.

--- a/packages/partysocket/src/index.ts
+++ b/packages/partysocket/src/index.ts
@@ -47,6 +47,8 @@ function generateUUID(): string {
 // TODO: incorporate the above notes
 export default class PartySocket extends ReconnectingWebSocket {
   _pk: string;
+  _pkurl: string;
+  name: string;
 
   constructor(readonly partySocketOptions: PartySocketOptions) {
     const {
@@ -77,9 +79,17 @@ export default class PartySocket extends ReconnectingWebSocket {
 
     super(url, protocols, socketOptions);
     this._pk = _pk;
+    this._pkurl = url;
+
+    this.name = party ?? "main";
   }
   get id() {
     return this._pk;
+  }
+
+  // partysocket has a static url, so we can just return that
+  get url(): string {
+    return this._pkurl;
   }
 }
 


### PR DESCRIPTION
This exposes the top level party 'name' on partysocket. Since urls for partysocket are 'static' we can also override the base implementation and expose the calculated url as well.