### PR TITLE
Fix deleting preview deployments

### DIFF
--- a/.changeset/quiet-mice-chew.md
+++ b/.changeset/quiet-mice-chew.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Fix deleting preview deployments

--- a/packages/partykit/schema.json
+++ b/packages/partykit/schema.json
@@ -16,6 +16,9 @@
     "port": {
       "type": "number"
     },
+    "preview": {
+      "type": "string"
+    },
     "serve": {
       "anyOf": [
         {

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -709,9 +709,11 @@ export async function _delete(options: {
     }
   );
 
-  logger.log(
-    `Deleted ${chalk.bold(`${config.name}.${user.login}.partykit.dev`)}`
-  );
+  const displayName = options.preview
+    ? `${options.preview}.${config.name}.${user.login}.partykit.dev`
+    : `${config.name}.${user.login}.partykit.dev`;
+
+  logger.log(`Deleted ${chalk.bold(displayName)}`);
 }
 
 type TailCreationApiResponse = {

--- a/packages/partykit/src/config-schema.ts
+++ b/packages/partykit/src/config-schema.ts
@@ -29,6 +29,7 @@ export const schema = z
     name: z.string().optional(),
     main: z.string().optional(),
     port: z.number().optional(),
+    preview: z.string().optional(),
     serve: z
       .union([
         z.string(),


### PR DESCRIPTION
While fixing #387,  I noticed that deleting preview deployments fails because the `preview` field is not allowed on `Config`.

This makes sense, because the `preview` field is a documented option on partykit json, but it can be provided as a config override with a `--preview` flag. 

I could have fixed this by removing the `preview` flag before we validate the config, but I think it would be useful to be able to set the `preview` flag in partykit.json, so I added it to the valid config schema instead.

