### PR TITLE
mark `clipboardy` as an external dependency

### DIFF
--- a/.changeset/young-terms-shop.md
+++ b/.changeset/young-terms-shop.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+mark `clipboardy` as an external dependency
+
+clipboardy comes with fallback binaries to use (esp. in windows). If we bundle it into the partykit bundle, then the references to those binaries fail. So we mark it as an external so it installs separately and resolves the binaries correctly.

--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.20230904.0",
+    "clipboardy": "^3.0.0",
     "esbuild": "^0.19.2",
     "miniflare": "^3.20230904.0",
     "yoga-wasm-web": "^0.3.3"
@@ -62,7 +63,6 @@
     "@types/ws": "^8.5.5",
     "chalk": "^5.3.0",
     "chokidar": "^3.5.3",
-    "clipboardy": "^3.0.0",
     "commander": "^11.0.0",
     "devtools-protocol": "^0.0.1195796",
     "dotenv": "^16.3.1",

--- a/packages/partykit/scripts/build.ts
+++ b/packages/partykit/scripts/build.ts
@@ -44,6 +44,7 @@ esbuild.buildSync({
     "esbuild",
     "fsevents",
     "miniflare",
+    "clipboardy",
   ],
   banner: isProd
     ? { js: "#!/usr/bin/env node" + createRequireSnippet }


### PR DESCRIPTION
clipboardy comes with fallback binaries to use (esp. in windows). If we bundle it into the partykit bundle, then the references to those binaries fail. So we mark it as an external so it installs separately and resolves the binaries correctly.