### PR TITLE
Change default login method to partykit

### DIFF
--- a/.changeset/witty-flies-flash.md
+++ b/.changeset/witty-flies-flash.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Change default login provider to "partykit"

--- a/packages/partykit/src/commands/login.tsx
+++ b/packages/partykit/src/commands/login.tsx
@@ -7,7 +7,7 @@ import { Text } from "ink";
 const read = asyncCache();
 
 export default function Login({ method }: { method?: LoginMethod }) {
-  const userConfig = read("get-user", () => getUser(method)) as Awaited<
+  const userConfig = read("get-user", () => getUser(method, true)) as Awaited<
     ReturnType<typeof getUser>
   >;
 

--- a/packages/partykit/src/config.ts
+++ b/packages/partykit/src/config.ts
@@ -39,7 +39,10 @@ export type UserConfig = z.infer<typeof userConfigSchema>;
 export type LoginMethod = UserConfig["type"];
 
 const USER_CONFIG_PATH = path.join(os.homedir(), ".partykit", "config.json");
-export async function getUser(loginMethod?: LoginMethod): Promise<UserConfig> {
+export async function getUser(
+  loginMethod?: LoginMethod,
+  exact: boolean = false
+): Promise<UserConfig> {
   const flags = getFlags();
   const method = loginMethod ?? flags.defaultLoginMethod;
 
@@ -48,9 +51,16 @@ export async function getUser(loginMethod?: LoginMethod): Promise<UserConfig> {
 
   try {
     userConfig = getUserConfig();
+
     if (!flags.supportedLoginMethods.includes(userConfig.type)) {
       throw new Error(
-        `Login method ${userConfig.type} is not supported, logging in again.`
+        `Login method ${userConfig.type} is no longer supported, logging in again.`
+      );
+    }
+
+    if (exact && method !== userConfig.type) {
+      throw new Error(
+        `User has logged in using another method, logging in again`
       );
     }
   } catch (e) {

--- a/packages/partykit/src/featureFlags.ts
+++ b/packages/partykit/src/featureFlags.ts
@@ -39,8 +39,8 @@ export function getFlags(): Flags {
       .then((flags) => {
         cachedFlags = flags;
       })
-      .catch((e) => {
-        //
+      .catch(() => {
+        // ignore, fall back to default settings
         return true;
       });
   }

--- a/packages/partykit/src/featureFlags.ts
+++ b/packages/partykit/src/featureFlags.ts
@@ -35,9 +35,14 @@ export function getFlags(): Flags {
     }
 
     // fetch remote flags and cache them locally for offline use for next time
-    void fetchFlags().then((flags) => {
-      cachedFlags = flags;
-    });
+    void fetchFlags()
+      .then((flags) => {
+        cachedFlags = flags;
+      })
+      .catch((e) => {
+        //
+        return true;
+      });
   }
 
   return {


### PR DESCRIPTION
This PR does the following:
- Makes `partykit login` use the PartyKit (Clerk) provider by default
- Changes `partykit login` behaviour so that if you have an old GitHub token, it will login again using the PartyKit provider
- Fixes a bug in feature flags implementation that prevented new flags being loaded

The feature flags in this case are not necessary as we are also changing the default config on the CLI side, but it'll be useful to switch back to GitHub in case we have any hiccups with the dashboard/clerk during the rollout.