### PR TITLE
Update CI guide

### DIFF
--- a/apps/docs/src/content/docs/guides/setting-up-ci-cd-with-github-actions.md
+++ b/apps/docs/src/content/docs/guides/setting-up-ci-cd-with-github-actions.md
@@ -9,15 +9,15 @@ To do so, you will first create a GitHub token and then set up a GitHub action.
 
 ### 1. Create a GitHub Token
 
-Open the project repository on GitHub and choose "Settings" from the top menu. Then, find "Secrets and variables" in the sidebar and choose "Actions" from the submenu. Finally, click "New repository secret."
+Create a GitHub Personal Access Token from [https://github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new). You can just give it a name & expiration and leave other inputs as is.
 
-Alternatively, you can create the token in your [Developer Settings](https://github.com/settings/tokens/new).
+Copy the token and add it to the project repository by going to "Settings" from the top menu of the repository. Then, find "Secrets and variables" in the sidebar and choose "Actions" from the submenu. Finally, click "New repository secret" to add the token.
 
 :::note
-For the purpose of this guide, let's assume that you have saved the token as `GITHUB_TOKEN`.
+For the purpose of this guide, let's assume that you have saved the token as `PARTYKIT_GITHUB_TOKEN`.
 :::
 
-Your API token is encrypted by GitHub and the action won't print it into logs.
+Your token is encrypted by GitHub and the action won't print it into logs.
 
 ### 2. Create a Github Action
 
@@ -45,7 +45,7 @@ jobs:
       - run: npm ci
       - run: npx partykit deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PARTYKIT_GITHUB_TOKEN }}
           GITHUB_LOGIN: threepointone # use your GitHub username
 ```
 

--- a/apps/docs/src/content/docs/guides/setting-up-ci-cd-with-github-actions.md
+++ b/apps/docs/src/content/docs/guides/setting-up-ci-cd-with-github-actions.md
@@ -9,7 +9,7 @@ To do so, you will first create a GitHub token and then set up a GitHub action.
 
 ### 1. Create a GitHub Token
 
-Create a GitHub Personal Access Token from [https://github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new). You can just give it a name & expiration and leave other inputs as is.
+Create a GitHub Personal Access Token from [https://github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new). You can give it a name & expiration, and leave the other inputs as is.
 
 Copy the token and add it to the project repository by going to "Settings" from the top menu of the repository. Then, find "Secrets and variables" in the sidebar and choose "Actions" from the submenu. Finally, click "New repository secret" to add the token.
 


### PR DESCRIPTION
Updated the CI guide based on my experience settings this up. It looks like you can't create a repository secret with name starting with `GITHUB_` (error message below for reference) 

<img width="884" alt="image" src="https://github.com/partykit/partykit/assets/450559/3bfd17f1-7e63-4e6c-adc6-117e407c20f3">

Also tweaked it to link to the page where you can create PAT, which is what I did.

Sample workflow which works for me - https://github.com/tsriram/svelte-party-demo/blob/321a8445bbf7322e8ec63962690922729fe1f510/.github/workflows/deploy-partykit.yml

Sample Action run for reference - https://github.com/tsriram/svelte-party-demo/actions/runs/6276609049

PS: Feel free to nitpick on the copy / edit it directly :)
