### PR TITLE
[fix] filePath in windows

### DIFF
--- a/.changeset/cool-peaches-argue.md
+++ b/.changeset/cool-peaches-argue.md
@@ -1,0 +1,9 @@
+---
+"partykit": patch
+---
+
+[fix] filePath in windows
+
+Fixes #328
+
+In Windows devices, the assetsMap was generating file paths with double backslashes, resulting in incorrect file paths. This PR addresses this issue by replacing the double backslashes with single forward slashes, ensuring that the file paths are correct and functional.

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -70,7 +70,10 @@ function* findAllFiles(
         }
         dirs.push(filePath);
       } else {
-        yield path.relative(root, filePath);
+        yield path.relative(
+          root,
+          filePath.replace(/\\/g, "/") // windows
+        );
       }
     }
   }

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -70,10 +70,7 @@ function* findAllFiles(
         }
         dirs.push(filePath);
       } else {
-        yield path.relative(
-          root,
-          filePath.replace(/\\/g, "/") // windows
-        );
+        yield path.relative(root, filePath).replace(/\\/g, "/"); // windows;
       }
     }
   }

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -512,10 +512,22 @@ export async function deploy(options: {
         path.extname(file)
       )}-${fileHash}${path.extname(file)}`;
 
-      newAssetsMap.assets[file] = fileName;
+      newAssetsMap.assets[
+        file.replace(
+          /\\/g, // windows
+          "/"
+        )
+      ] = fileName;
 
       // if the file is already uploaded, skip it
-      if (currentAssetsMap.assets[file] !== fileName) {
+      if (
+        currentAssetsMap.assets[
+          file.replace(
+            /\\/g, // windows
+            "/"
+          )
+        ] !== fileName
+      ) {
         filesToUpload.push({
           file,
           filePath,
@@ -542,7 +554,12 @@ export async function deploy(options: {
           },
           duplex: "half",
         });
-        logger.log(`Uploaded ${file.file}`);
+        logger.log(
+          `Uploaded ${file.file.replace(
+            /\\/g, // windows
+            "/"
+          )}`
+        );
       }
     }
 

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -300,10 +300,7 @@ function* findAllFiles(
         }
         dirs.push(filePath);
       } else {
-        yield path.relative(
-          root,
-          filePath.replace(/\\/g, "/") // windows
-        );
+        yield path.relative(root, filePath).replace(/\\/g, "/"); // windows;
       }
     }
   }

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -505,6 +505,20 @@ function useDev(options: DevProps): {
         "utf8"
       );
 
+      //replace \\ with / in windows
+      //the default output for assets in windows is {"dist\\index.js": "dist\\index.js"}[]
+      for (const key in assetsMap.assets) {
+        if (assetsMap.assets[key].includes("\\")) {
+          const updatedKey = key.replace(/\\/g, "/");
+          const updatedValue = assetsMap.assets[key].replace(/\\/g, "/");
+
+          assetsMap.assets[updatedKey] = updatedValue;
+
+          //delete the key with \\
+          delete assetsMap.assets[key];
+        }
+      }
+
       const absoluteScriptPath = path.join(process.cwd(), config.main!).replace(
         /\\/g, // windows
         "/"


### PR DESCRIPTION
 Fixes #328 
 
 In Windows devices, the assetsMap was generating file paths with double backslashes, resulting in incorrect file paths. This PR addresses this issue by replacing the double backslashes with single forward slashes, ensuring that the file paths are correct and functional. 