### PR TITLE
fix: work on node 16 again

### DIFF
--- a/.changeset/three-pants-search.md
+++ b/.changeset/three-pants-search.md
@@ -1,0 +1,8 @@
+---
+"create-partykit": patch
+"partykit": patch
+---
+
+fix: work on node 16 again
+
+some references to `fetch` weren't being imported from undici. global fetch was introduced only in node 18. so the partykit cli (specifically `init`) and create-partykit weren't working on node 16. This fixes that issue (tho we should phase out node 16 support soon)

--- a/package-lock.json
+++ b/package-lock.json
@@ -28299,9 +28299,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.24.0.tgz",
-      "integrity": "sha512-OKlckxBjFl0oXxcj9FU6oB8fDAaiRUq+D8jrFWGmOfI/gIyjk/IeS75LMzgYKUaeHzLUcYvf9bbJGSrUwTfwwQ==",
+      "version": "5.25.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.25.2.tgz",
+      "integrity": "sha512-tch8RbCfn1UUH1PeVCXva4V8gDpGAud/w0WubD6sHC46vYQ3KDxL+xv1A2UxK0N6jrVedutuPHxe1XIoqerwMw==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -30064,6 +30064,7 @@
         "random-words": "^2.0.0",
         "react": "^18.2.0",
         "typescript": "^5.2.2",
+        "undici": "^5.25.2",
         "which-pm-runs": "^1.1.0"
       },
       "optionalDependencies": {
@@ -30631,7 +30632,7 @@
         "react-error-boundary": "^4.0.11",
         "signal-exit": "^4.1.0",
         "source-map": "^0.7.4",
-        "undici": "^5.24.0",
+        "undici": "^5.25.2",
         "update-notifier": "^6.0.2",
         "which-pm-runs": "^1.1.0",
         "ws": "^8.14.2",

--- a/packages/create-partykit/package.json
+++ b/packages/create-partykit/package.json
@@ -39,6 +39,7 @@
     "random-words": "^2.0.0",
     "react": "^18.2.0",
     "typescript": "^5.2.2",
+    "undici": "^5.25.2",
     "which-pm-runs": "^1.1.0"
   }
 }

--- a/packages/create-partykit/src/index.tsx
+++ b/packages/create-partykit/src/index.tsx
@@ -2,6 +2,7 @@ import { Text, render } from "ink";
 import * as React from "react";
 import TextInput from "ink-text-input";
 import SelectInput from "ink-select-input";
+import { fetch } from "undici";
 
 import * as RandomWords from "random-words";
 
@@ -166,14 +167,14 @@ export async function init(options: {
       latestPartyKitVersion = await fetch(
         `https://registry.npmjs.org/partykit/latest`
       )
-        .then((res) => res.json())
-        .then((res) => res.version as string);
+        .then((res) => res.json() as Promise<{ version: string }>)
+        .then((res) => res.version);
 
       latestPartySocketVersion = await fetch(
         `https://registry.npmjs.org/partysocket/latest`
       )
-        .then((res) => res.json())
-        .then((res) => res.version as string);
+        .then((res) => res.json() as Promise<{ version: string }>)
+        .then((res) => res.version);
     } catch (e) {
       console.error(
         "Could not fetch latest versions of partykit and partysocket, defaulting to *"

--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -84,7 +84,7 @@
     "react-error-boundary": "^4.0.11",
     "signal-exit": "^4.1.0",
     "source-map": "^0.7.4",
-    "undici": "^5.24.0",
+    "undici": "^5.25.2",
     "update-notifier": "^6.0.2",
     "which-pm-runs": "^1.1.0",
     "ws": "^8.14.2",

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -2,7 +2,7 @@
 import path from "path";
 import * as fs from "fs";
 import { fetchResult } from "./fetchResult";
-import { File, FormData } from "undici";
+import { fetch, File, FormData } from "undici";
 import type { BuildOptions } from "esbuild";
 import * as crypto from "crypto";
 import WebSocket from "ws";
@@ -132,14 +132,14 @@ export async function init(options: {
       latestPartyKitVersion = await fetch(
         `https://registry.npmjs.org/partykit/latest`
       )
-        .then((res) => res.json())
-        .then((res) => res.version as string);
+        .then((res) => res.json() as Promise<{ version: string }>)
+        .then((res) => res.version);
 
       latestPartySocketVersion = await fetch(
         `https://registry.npmjs.org/partysocket/latest`
       )
-        .then((res) => res.json())
-        .then((res) => res.version as string);
+        .then((res) => res.json() as Promise<{ version: string }>)
+        .then((res) => res.version);
     } catch (e) {
       logger.error(
         "Could not fetch latest versions of partykit and partysocket, defaulting to *"


### PR DESCRIPTION
some references to `fetch` weren't being imported from undici. global fetch was introduced only in node 18. so the partykit cli (specifically `init`) and create-partykit weren't working on node 16. This fixes that issue (tho we should phase out node 16 support soon)