### PR TITLE
Use existing indentation of package.json during partykit init

### DIFF
--- a/.changeset/red-parents-suffer.md
+++ b/.changeset/red-parents-suffer.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Use existing indentation of package.json when running partykit init

--- a/package-lock.json
+++ b/package-lock.json
@@ -30592,6 +30592,7 @@
       "dependencies": {
         "@cloudflare/workers-types": "4.20230914.0",
         "clipboardy": "3.0.0",
+        "detect-indent": "^7.0.1",
         "esbuild": "0.19.3",
         "miniflare": "3.20230918.0",
         "yoga-wasm-web": "0.3.3"
@@ -30982,6 +30983,14 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
       "dev": true
+    },
+    "packages/partykit/node_modules/detect-indent": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.1.tgz",
+      "integrity": "sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "packages/partykit/node_modules/dotenv": {
       "version": "16.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30592,7 +30592,6 @@
       "dependencies": {
         "@cloudflare/workers-types": "4.20230914.0",
         "clipboardy": "3.0.0",
-        "detect-indent": "^7.0.1",
         "esbuild": "0.19.3",
         "miniflare": "3.20230918.0",
         "yoga-wasm-web": "0.3.3"
@@ -30613,6 +30612,7 @@
         "chalk": "^5.3.0",
         "chokidar": "^3.5.3",
         "commander": "^11.0.0",
+        "detect-indent": "^7.0.1",
         "devtools-protocol": "^0.0.1196408",
         "dotenv": "^16.3.1",
         "dotenv-cli": "^7.3.0",
@@ -30988,6 +30988,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.1.tgz",
       "integrity": "sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==",
+      "dev": true,
       "engines": {
         "node": ">=12.20"
       }

--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@cloudflare/workers-types": "4.20230914.0",
     "clipboardy": "3.0.0",
+    "detect-indent": "^7.0.1",
     "esbuild": "0.19.3",
     "miniflare": "3.20230918.0",
     "yoga-wasm-web": "0.3.3"

--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "@cloudflare/workers-types": "4.20230914.0",
     "clipboardy": "3.0.0",
-    "detect-indent": "^7.0.1",
     "esbuild": "0.19.3",
     "miniflare": "3.20230918.0",
     "yoga-wasm-web": "0.3.3"
@@ -65,6 +64,7 @@
     "chalk": "^5.3.0",
     "chokidar": "^3.5.3",
     "commander": "^11.0.0",
+    "detect-indent": "^7.0.1",
     "devtools-protocol": "^0.0.1196408",
     "dotenv": "^16.3.1",
     "dotenv-cli": "^7.3.0",

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -19,6 +19,7 @@ export { Dev };
 export type { DevProps };
 
 import { execaCommand, execaCommandSync } from "execa";
+import detectIndent from "detect-indent";
 import { version as packageVersion } from "../package.json";
 
 import {
@@ -151,7 +152,9 @@ export async function init(options: {
   }
 
   if (packageJsonPath) {
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    const packageJsonFile = fs.readFileSync(packageJsonPath, "utf8");
+    const packageJsonIndent = detectIndent(packageJsonFile).indent || 2;
+    const packageJson = JSON.parse(packageJsonFile);
     // if there's an existing package.json, we're in a project
     // ask the user whether they want to add to it, or create a new one
     const shouldAddToExisting =
@@ -214,7 +217,7 @@ export async function init(options: {
         // write the package.json back
         fs.writeFileSync(
           packageJsonPath,
-          JSON.stringify(packageJson, null, 2) + "\n"
+          JSON.stringify(packageJson, null, packageJsonIndent) + "\n"
         );
       } else {
         console.log(


### PR DESCRIPTION
Currently when you run `npx partykit@latest init` in an existing project and choose to add partykit to existing `package.json`, we add dependencies to the JSON content and write it back to `package.json` file with 2 spaces here: https://github.com/partykit/partykit/blob/a01be0da91b0b8b18cc50a63bb2a655b08178455/packages/partykit/src/cli.tsx#L217

This is a problem when the existing `package.json` uses a different indentation like 4 spaces / tabs since it's a bit confusing to see a huge `git diff` after the command. Ran into this when running `npx partykit@latest init` in a SvelteKit project since it uses tabs for formatting by default. While one can run re-format the file to see the actual diff, I think it'll be a good experience to keep the existing indentation. And @sindresorhus has a module just for this 😄 

I tried this code locally and everything looks to be working fine. 