### PR TITLE
Make it more clear in docs how host name is built

### DIFF
--- a/apps/docs/src/content/docs/reference/partysocket-api.md
+++ b/apps/docs/src/content/docs/reference/partysocket-api.md
@@ -40,7 +40,7 @@ npm install partysocket@latest
 import PartySocket from "partysocket";
 
 const ws = new PartySocket({
-  host: "project-name.partykit.dev", // or localhost:1999 in dev
+  host: "project-name.username.partykit.dev", // or localhost:1999 in dev
   room: "my-room",
   // add an optional id to identify the client,
   // if not provided, a random id will be generated
@@ -64,7 +64,7 @@ import usePartySocket from "partysocket/react";
 const Component = () => {
   const ws = usePartySocket({
     // usePartySocket takes the same arguments as PartySocket.
-    host: "project.name.partykit.dev", // or localhost:1999 in dev
+    host: "project-name.username.partykit.dev", // or localhost:1999 in dev
     room: "my-room",
 
     // in addition, you can provide socket lifecycle event handlers

--- a/apps/docs/src/content/docs/reference/partysocket-api.md
+++ b/apps/docs/src/content/docs/reference/partysocket-api.md
@@ -40,7 +40,7 @@ npm install partysocket@latest
 import PartySocket from "partysocket";
 
 const ws = new PartySocket({
-  host: "project.name.partykit.dev", // or localhost:1999 in dev
+  host: "project-name.partykit.dev", // or localhost:1999 in dev
   room: "my-room",
   // add an optional id to identify the client,
   // if not provided, a random id will be generated


### PR DESCRIPTION
Presumably this is what comes from partykit.json. If dots are possible, it at least makes the docs slightly more confusing, because it's ambiguous if the host is something like `party.my-project.party.dev`