### PR TITLE
fixed typo in docs for PartySocket (Client Api)

### DIFF
--- a/apps/docs/src/content/docs/reference/partysocket-api.md
+++ b/apps/docs/src/content/docs/reference/partysocket-api.md
@@ -76,10 +76,10 @@ const Component = () => {
       console.log("message", e.data);
     },
     onClose() {
-      console.log("connected");
+      console.log("closed");
     },
     onError(e) {
-      console.log("connected");
+      console.log("error");
     },
   });
 };


### PR DESCRIPTION
lol I thought there was a bug in the partySocket lib when I was seeing the log `connected` even when the servers were not running, turns out it was a typo in the docs from where I copy/pasted the code. Fixed that 