### PR TITLE
add a default compatibility date

### DIFF
--- a/.changeset/kind-brooms-flash.md
+++ b/.changeset/kind-brooms-flash.md
@@ -1,0 +1,8 @@
+---
+"create-partykit": patch
+"partykit": patch
+---
+
+add a default compatibility date
+
+We should be adding a default compatibility date to new projects. Further, for projects that don't have one, we should warn that they should, and default to the latest compatibility date that we can. This PR adds that behaviour for both create, dev and deploy

--- a/apps/docs/src/content/docs/reference/partykit-configuration.md
+++ b/apps/docs/src/content/docs/reference/partykit-configuration.md
@@ -6,6 +6,7 @@ description: PartyKit Configuration reference
 This is a reference of all the fields you can add to your `partykit.json` file to configure the behaviour of your project.
 
 ## Project configuration
+
 ### name
 
 The name of your project. This is used to identify your project on the platform, and is also used to generate the url for your project (typically `https://<name>.<user>.partykit.dev`) For example:
@@ -18,10 +19,10 @@ The name of your project. This is used to identify your project on the platform,
 
 Alternately, you can pass this as an argument to the `dev` or `deploy` commands, like this: `npx partykit dev --name my-project`
 
-
 ### main
 
-The entrypoint for your project. This is where you'd define a default export as specified by the [PartyKit API](/reference/partyserver-api/). For example: 
+The entrypoint for your project. This is where you'd define a default export as specified by the [PartyKit API](/reference/partyserver-api/). For example:
+
 ```json
 {
   "main": "src/server.ts"
@@ -81,7 +82,7 @@ Related guide: [Serving static assets](/guides/serving-static-assets/)
 ### vars
 
 :::danger[Deprecated]
-The `vars` field is deprecated and may be removed in a future version of PartyKit. 
+The `vars` field is deprecated and may be removed in a future version of PartyKit.
 
 For updated documentation, read [Managing environment variables in PartyKit](/guides/managing-environment-variables/)
 :::
@@ -122,9 +123,7 @@ Path to persist the party storage to in development mode. Defaults to `.partykit
 }
 ```
 
-Set to `false` if you don't want to persist storage between dev server restarts. 
-
-
+Set to `false` if you don't want to persist storage between dev server restarts.
 
 With a configuration like that, you could then access the variable in your code like this:
 
@@ -138,7 +137,6 @@ export default {
 ```
 
 Related guide: [Managing environment variables in PartyKit](/guides/managing-environment-variables/)
-
 
 ## Build configuration
 
@@ -188,6 +186,7 @@ export default {
 ### minify
 
 Whether to minify the JavaScript build output before deploying. Defaults to `true`.
+
 ```json
 {
   "minify": false
@@ -202,7 +201,7 @@ Cloudflare Workers API [Compatibility date](https://developers.cloudflare.com/wo
 
 ```json
 {
-  "compatibilityDate": "2023-04-11"
+  "compatibilityDate": "2023-09-27"
 }
 ```
 
@@ -215,5 +214,3 @@ Additional Cloudflare Workers API [Compatibility flags](https://developers.cloud
   "compatibilityFlags": ["web_socket_compression"]
 }
 ```
-
-

--- a/packages/create-partykit/js-template/partykit.json
+++ b/packages/create-partykit/js-template/partykit.json
@@ -1,6 +1,7 @@
 {
   "name": "$PROJECT_NAME",
   "main": "src/server.js",
+  "compatibilityDate": "$COMPATIBILITY_DATE",
   "serve": {
     "path": "public",
     "build": "src/client.js"

--- a/packages/create-partykit/src/index.tsx
+++ b/packages/create-partykit/src/index.tsx
@@ -358,13 +358,21 @@ export async function init(options: {
       path.join(pathToProject, ".gitignore")
     );
 
-    // replace $PROJECT_NAME in partykit.json
+    const today = new Date();
+
+    // replace $PROJECT_NAME & $COMPATIBILITY_DATE in partykit.json
     const partykitJsonPath = path.join(pathToProject, "partykit.json");
     fs.writeFileSync(
       partykitJsonPath,
       fs
         .readFileSync(partykitJsonPath, { encoding: "utf-8" })
         .replace(/\$PROJECT_NAME/g, projectName)
+        .replace(
+          /\$COMPATIBILITY_DATE/g,
+          `${today.getFullYear()}-${(today.getMonth() + 1)
+            .toString()
+            .padStart(2, "0")}-${today.getDate().toString().padStart(2, "0")}`
+        )
     );
     // do the same with README.md
     const readmePath = path.join(pathToProject, "README.md");

--- a/packages/create-partykit/ts-template/partykit.json
+++ b/packages/create-partykit/ts-template/partykit.json
@@ -1,6 +1,7 @@
 {
   "name": "$PROJECT_NAME",
   "main": "src/server.ts",
+  "compatibilityDate": "$COMPATIBILITY_DATE",
   "serve": {
     "path": "public",
     "build": "src/client.ts"

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -229,12 +229,21 @@ export async function init(options: {
 
       if (!options.dryRun) {
         // make a partykit.json file
+
+        const today = new Date();
+        const defaultCompatibilityDate = `${today.getFullYear()}-${(
+          today.getMonth() + 1
+        )
+          .toString()
+          .padStart(2, "0")}-${today.getDate().toString().padStart(2, "0")}`;
+
         fs.writeFileSync(
           path.join(process.cwd(), "partykit.json"),
           JSON.stringify(
             {
               name: options.name || `${packageJson.name || "my"}-party`,
               main: isTypeScriptProject ? "party/index.ts" : "party/index.js",
+              compatibilityDate: defaultCompatibilityDate,
             },
             null,
             2
@@ -665,6 +674,23 @@ export const ${name} = ${name}Party;
 
   if (config.compatibilityDate) {
     form.set("compatibilityDate", config.compatibilityDate);
+  } else {
+    const today = new Date();
+    const defaultCompatibilityDate = `${today.getFullYear()}-${(
+      today.getMonth() + 1
+    )
+      .toString()
+      .padStart(2, "0")}-${today.getDate().toString().padStart(2, "0")}`;
+
+    logger.warn(
+      `No compatibilityDate specified in configuration, defaulting to ${defaultCompatibilityDate}
+You can silence this warning by adding this to your partykit.json file: 
+  "compatibilityDate": "${defaultCompatibilityDate}"
+or by passing it in via the CLI
+  --compatibility-date ${defaultCompatibilityDate}
+`
+    );
+    form.set("compatibilityDate", defaultCompatibilityDate);
   }
   if (config.compatibilityFlags) {
     form.set("compatibilityFlags", JSON.stringify(config.compatibilityFlags));

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -501,6 +501,40 @@ function useDev(options: DevProps): {
   }
 
   useEffect(() => {
+    const today = new Date();
+    const latestCompatibilityDate = `${today.getFullYear()}-${(
+      today.getMonth() + 1
+    )
+      .toString()
+      .padStart(2, "0")}-${today.getDate().toString().padStart(2, "0")}`;
+
+    if (!config.compatibilityDate) {
+      logger.warn(
+        `No compatibilityDate specified in configuration, defaulting to ${latestCompatibilityDate}
+    You can silence this warning by adding this to your partykit.json file: 
+      "compatibilityDate": "${latestCompatibilityDate}"
+    or by passing it in via the CLI
+      --compatibility-date ${latestCompatibilityDate}`
+      );
+    }
+
+    let compatibilityDate: string;
+    if (config.compatibilityDate) {
+      const minDate = new Date(
+        Math.min(
+          new Date(config.compatibilityDate).getTime(),
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          new Date(require("workerd").compatibilityDate).getTime()
+        )
+      );
+      compatibilityDate = `${minDate.getFullYear()}-${(minDate.getMonth() + 1)
+        .toString()
+        .padStart(2, "0")}-${minDate.getDate().toString().padStart(2, "0")}`;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      compatibilityDate = require("workerd").compatibilityDate;
+    }
+
     let customBuildFolderWatcher: ReturnType<typeof chokidar.watch> | undefined;
     let ctx: BuildContext | undefined;
     const abortController = new AbortController();
@@ -606,8 +640,7 @@ Workers["${name}"] = ${name};
                       verbose: options.verbose,
                       inspectorPort: portForRuntimeInspector,
 
-                      compatibilityDate:
-                        config.compatibilityDate || "2023-04-11",
+                      compatibilityDate,
                       compatibilityFlags: [
                         "nodejs_compat",
                         ...(config.compatibilityFlags || []),

--- a/packages/partykit/src/tests/deploy.test.ts
+++ b/packages/partykit/src/tests/deploy.test.ts
@@ -283,6 +283,7 @@ describe("deploy", () => {
       JSON.stringify({
         name: "test-script",
         serve: "./public",
+        compatibilityDate: "2023-09-28",
       })
     );
 


### PR DESCRIPTION
We should be adding a default compatibility date to new projects. Further, for projects that don't have one, we should warn that they should, and default to the latest compatibility date that we can. This PR adds that behaviour for both create, dev and deploy