### PR TITLE
Ensure that user attachments don't clobber system attachments used by PartyKit

### DIFF
--- a/.changeset/rare-insects-poke.md
+++ b/.changeset/rare-insects-poke.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Ensure that user attachments don't clobber system attachments used by partykit

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -78,6 +78,11 @@ export type Connection = WebSocket & {
   // It's also set as readonly, so we can't set it ourselves.
   // Instead, we'll use the `uri` property.
   uri: string;
+
+  // Underlying cloudflare types specify the type as any, but unknown is safer
+  // as it forces a cast, so let's add a optional generic overload
+  serializeAttachment<T = unknown>(attachment: T): void;
+  deserializeAttachment<T = unknown>(): T | null;
 };
 
 /** Party represents a single, self-contained, long-lived session. */


### PR DESCRIPTION
Fixes #434 
Fixes root cause for performance issue https://github.com/partykit/sketch-voronoi/pull/4

## Problem 

1. In hibernation mode, PartyKit stores basic connection information such as connection id and url in the websocket attachments, so that we can regain access to them when the object wakes up from hibernation.
2. Any user invocation of`serializeAttachment` overwrote the fields internally managed by PartyKit
3. When the object next wakes up in reaction to a message, we assert that the information we store is still present. This assertion fails, and causes a silent error.

## Fix

We "namespace' partykit fields and user fields, and patch the `serializeAttachment` and `deserializeAttachment` fields to return only the value from the user namespace. Internally, we use the getters for the private fields, so no changes to internal platform implementation required.

This is a backwards-compatible change. 

There are a couple of subtle non-breaking behavioural changes, which I'll note inline in the review.



