### PR TITLE
Add new `connection.state` / `connection.setState` API

### DIFF
--- a/packages/partykit/facade/connection.ts
+++ b/packages/partykit/facade/connection.ts
@@ -189,8 +189,7 @@ export class InMemoryConnectionManager implements ConnectionManager {
     return this.connections;
   }
 
-  accept(connection: Party.Connection, tags: string[]): void {
-    connection = createStatefulConnection(connection);
+  accept(connection: Party.Connection, tags: string[]) {
     connection.accept();
 
     this.connections.set(connection.id, connection);

--- a/packages/partykit/facade/connection.ts
+++ b/packages/partykit/facade/connection.ts
@@ -71,63 +71,89 @@ export const createLazyConnection = (
     return ws;
   }
 
-  const connection = Object.assign(ws, {
-    get id() {
-      return attachments.get(ws).__pk.id;
+  // if state was set on the socket before initializing the connection,
+  // capture it here so we can persist it again
+  let initialState = undefined;
+  if ("state" in ws) {
+    initialState = ws.state;
+    delete ws.state;
+  }
+
+  const connection = Object.defineProperties(ws, {
+    id: {
+      get() {
+        return attachments.get(ws).__pk.id;
+      },
     },
-    get uri() {
-      return attachments.get(ws).__pk.uri;
+    uri: {
+      get() {
+        return attachments.get(ws).__pk.uri;
+      },
     },
-    get socket() {
-      return ws;
+    socket: {
+      get() {
+        return ws;
+      },
     },
-    get state() {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-      return this.deserializeAttachment() as Party.ConnectionState<unknown>;
+    state: {
+      get() {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        return this.deserializeAttachment() as Party.ConnectionState<unknown>;
+      },
+    },
+    setState: {
+      value: function setState<T>(setState: T | Party.ConnectionSetStateFn<T>) {
+        let state: T;
+        if (setState instanceof Function) {
+          state = setState((this as Party.Connection<T>).state);
+        } else {
+          state = setState;
+        }
+
+        this.serializeAttachment(state);
+        return state as Party.ConnectionState<T>;
+      },
     },
 
-    setState<T>(setState: T | Party.ConnectionSetStateFn<T>) {
-      let state: T;
-      if (setState instanceof Function) {
-        state = setState(this.state as Party.ConnectionState<T>);
-      } else {
-        state = setState;
-      }
-
-      // TODO: deepFreeze object?
-
-      this.serializeAttachment(state);
-      return state as Party.ConnectionState<T>;
+    deserializeAttachment: {
+      value: function deserializeAttachment<T = unknown>() {
+        const attachment = attachments.get(ws);
+        return (attachment.__user ?? null) as T;
+      },
     },
 
-    deserializeAttachment<T = unknown>() {
-      const attachment = attachments.get(ws);
-      return (attachment.__user ?? null) as T;
+    serializeAttachment: {
+      value: function serializeAttachment<T = unknown>(attachment: T) {
+        const setting = {
+          ...attachments.get(ws),
+          __user: attachment ?? null,
+        };
+
+        attachments.set(ws, setting);
+      },
     },
-    serializeAttachment<T = unknown>(attachment: T) {
-      attachments.set(ws, {
-        ...attachments.get(ws),
-        __user: attachment ?? null,
-      });
-    },
-  });
+  }) as Party.Connection;
+
+  if (initialState) {
+    connection.setState(initialState);
+  }
 
   connections.add(connection);
   return connection;
 };
 
-class HibernatingConnectionIterator
-  implements IterableIterator<Party.Connection>
+class HibernatingConnectionIterator<T>
+  implements IterableIterator<Party.Connection<T>>
 {
   private index: number = 0;
   private sockets: WebSocket[] | undefined;
   constructor(private state: DurableObjectState, private tag?: string) {}
 
-  [Symbol.iterator](): IterableIterator<Party.Connection> {
+  [Symbol.iterator](): IterableIterator<Party.Connection<T>> {
     return this;
   }
 
-  next(): IteratorResult<Party.Connection, number | undefined> {
+  next(): IteratorResult<Party.Connection<T>, number | undefined> {
     const sockets =
       this.sockets ?? (this.sockets = this.state.getWebSockets(this.tag));
 
@@ -135,7 +161,7 @@ class HibernatingConnectionIterator
     while ((socket = sockets[this.index++])) {
       // only yield open sockets to match non-hibernating behaviour
       if (socket.readyState === WebSocket.READY_STATE_OPEN) {
-        const value = createLazyConnection(socket);
+        const value = createLazyConnection(socket) as Party.Connection<T>;
         return { done: false, value };
       }
     }
@@ -147,8 +173,10 @@ class HibernatingConnectionIterator
 
 export interface ConnectionManager {
   getCount(): number;
-  getConnection(id: string): Party.Connection | undefined;
-  getConnections(tag?: string): IterableIterator<Party.Connection>;
+  getConnection<TState>(id: string): Party.Connection<TState> | undefined;
+  getConnections<TState>(
+    tag?: string
+  ): IterableIterator<Party.Connection<TState>>;
   accept(connection: Party.Connection, tags: string[]): Party.Connection;
 
   // This can be removed when Party.connections is removed
@@ -158,7 +186,7 @@ export interface ConnectionManager {
 /**
  * When not using hibernation, we track active connections manually.
  */
-export class InMemoryConnectionManager implements ConnectionManager {
+export class InMemoryConnectionManager<TState> implements ConnectionManager {
   connections: Map<string, Party.Connection> = new Map();
   tags: WeakMap<Party.Connection, string[]> = new WeakMap();
 
@@ -166,13 +194,15 @@ export class InMemoryConnectionManager implements ConnectionManager {
     return this.connections.size;
   }
 
-  getConnection(id: string) {
-    return this.connections.get(id);
+  getConnection<T = TState>(id: string) {
+    return this.connections.get(id) as Party.Connection<T> | undefined;
   }
 
-  *getConnections(tag?: string): IterableIterator<Party.Connection> {
+  *getConnections<T = TState>(
+    tag?: string
+  ): IterableIterator<Party.Connection<T>> {
     if (!tag) {
-      yield* this.connections.values();
+      yield* this.connections.values() as IterableIterator<Party.Connection<T>>;
       return;
     }
 
@@ -180,7 +210,7 @@ export class InMemoryConnectionManager implements ConnectionManager {
     for (const connection of this.connections.values()) {
       const connectionTags = this.tags.get(connection) ?? [];
       if (connectionTags.includes(tag)) {
-        yield connection;
+        yield connection as Party.Connection<T>;
       }
     }
   }
@@ -214,26 +244,27 @@ export class InMemoryConnectionManager implements ConnectionManager {
 /**
  * When opting into hibernation, the platform tracks connections for us.
  */
-export class HibernatingConnectionManager implements ConnectionManager {
+export class HibernatingConnectionManager<TState> implements ConnectionManager {
   constructor(private controller: DurableObjectState) {}
 
   getCount() {
     return Number(this.controller.getWebSockets().length);
   }
 
-  getConnection(id: string) {
+  getConnection<T = TState>(id: string) {
     // TODO: Should we cache the connections?
     const sockets = this.controller.getWebSockets(id);
     if (sockets.length === 0) return undefined;
-    if (sockets.length === 1) return createLazyConnection(sockets[0]);
+    if (sockets.length === 1)
+      return createLazyConnection(sockets[0]) as Party.Connection<T>;
 
     throw new Error(
       `More than one connection found for id ${id}. Did you mean to use getConnections(tag) instead?`
     );
   }
 
-  getConnections(tag?: string | undefined) {
-    return new HibernatingConnectionIterator(this.controller, tag);
+  getConnections<T = TState>(tag?: string | undefined) {
+    return new HibernatingConnectionIterator<T>(this.controller, tag);
   }
 
   legacy_getConnectionMap() {

--- a/packages/partykit/facade/connection.ts
+++ b/packages/partykit/facade/connection.ts
@@ -97,7 +97,6 @@ export const createLazyConnection = (
     },
     state: {
       get() {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         return this.deserializeAttachment() as Party.ConnectionState<unknown>;
       },
     },

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -228,9 +228,9 @@ function createDurable(
             );
           },
         },
-        getConnection(id: string) {
+        getConnection<TState = unknown>(id: string) {
           if (self.connectionManager) {
-            return self.connectionManager.getConnection(id);
+            return self.connectionManager.getConnection<TState>(id);
           }
 
           console.warn(
@@ -239,9 +239,9 @@ function createDurable(
           return undefined;
         },
 
-        getConnections(tag?: string) {
+        getConnections<TState = unknown>(tag?: string) {
           if (self.connectionManager) {
-            return self.connectionManager.getConnections(tag);
+            return self.connectionManager.getConnections<TState>(tag);
           }
 
           console.warn(

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -228,9 +228,9 @@ function createDurable(
             );
           },
         },
-        getConnection<TState = unknown>(id: string) {
+        getConnection(id: string) {
           if (self.connectionManager) {
-            return self.connectionManager.getConnection<TState>(id);
+            return self.connectionManager.getConnection(id);
           }
 
           console.warn(
@@ -239,9 +239,9 @@ function createDurable(
           return undefined;
         },
 
-        getConnections<TState = unknown>(tag?: string) {
+        getConnections(tag?: string) {
           if (self.connectionManager) {
-            return self.connectionManager.getConnections<TState>(tag);
+            return self.connectionManager.getConnections(tag);
           }
 
           console.warn(
@@ -351,7 +351,7 @@ function createDurable(
           socket: serverWebSocket,
           uri: request.url,
           state: null as unknown as Party.ConnectionState<unknown>,
-          setState<T>(setState: T | Party.ConnectionSetStateFn<T>) {
+          setState<T = unknown>(setState: T | Party.ConnectionSetStateFn<T>) {
             let state: T;
             if (setState instanceof Function) {
               state = setState(this.state as Party.ConnectionState<T>);

--- a/packages/y-partykit/src/provider.ts
+++ b/packages/y-partykit/src/provider.ts
@@ -246,6 +246,7 @@ type AwarenessUpdate = {
  *
  * @extends {Observable<string>}
  */
+// eslint-disable-next-line deprecation/deprecation
 export class WebsocketProvider extends Observable<string> {
   maxBackoffTime: number;
   bcChannel: string;

--- a/packages/y-partykit/src/provider.ts
+++ b/packages/y-partykit/src/provider.ts
@@ -246,7 +246,6 @@ type AwarenessUpdate = {
  *
  * @extends {Observable<string>}
  */
-// eslint-disable-next-line deprecation/deprecation
 export class WebsocketProvider extends Observable<string> {
   maxBackoffTime: number;
   bcChannel: string;


### PR DESCRIPTION
## Proposal

I'm proposing the following API to replace the current serialize/deserializeAttachment API:

```ts
type State = { foo: string, baz?: number } ;

onConnect(conn: Party.Connection<State>) {
  // set state
  conn.setState({ foo: "bar"  });
 
  // read state
  console.log(conn.state); // { foo: "bar" }

  // update state
  const updatedState = conn.setState(prevState => ({ ...prevState, baz: 1 });;
  console.log(updatedState) // { foo: "bar", baz: 1 };
}
```

A more complete example of what this change would look like in user code: https://github.com/partykit/sketch-voronoi/pull/5/files

The same API works for hibernating and non-hibernating connections, and provides optional type safety by adding a generic parameter on `Connection`.

## TODO

- [x] Basic implementation
- [x] Decide on final API
- [x] Implement in platform
- [x] Fix TODOs

## Rationale

In the last week, we've ran into a number of issues with the WebSocket attachment API. The previous PR in this stack (https://github.com/partykit/partykit/pull/437) fixes some of the correctness and performance issues, but still leaves more to be desired:


1. When not in hibernation mode, you can keep state by assigning it to the `connection` object:

```tsx
onConnect(conn: Party.Connection) {
  conn.foo = "bar";
}
```

2. However, if you’re using TypeScript, this will cause a type error, for which you need to do a manual upcast, which is not obvious and feels hacky:

```tsx
onConnect(conn: Party.Connection & { foo?: string }) {
  conn.foo = "bar";
}
```

3. This works, but when you enter hibernation mode, this stops working as soon as the socket hibernates, so you need to serialize the attachment:

```tsx
onConnect(conn: Party.Connection & { foo?: string }) {
  conn.serializeAttachment({ foo: "bar" });
  //later...
  const data = conn.deserializeAttachment();
  console.log(data.foo);
}
```

4. While `serializeAttachment` and `deserializeAttachment` work without hibernation mode, they are unintuitive and don't make sense when the connection stays in memory.
5. `serializeAttachment` is not additive — a socket can only have one attachment, so when you want to edit it, you need to do an awkward read/write:
```ts
  conn.serializeAttachment({ 
    ...(conn.deserializeAttachment()),
    foo: "bar" 
   });
```