### PR TITLE
experimental: `dev --unstable_outdir <path>`

### DIFF
--- a/.changeset/famous-peas-smoke.md
+++ b/.changeset/famous-peas-smoke.md
@@ -1,0 +1,11 @@
+---
+"partykit": patch
+---
+
+experimental: `dev --unstable_outdir <path>`
+
+When we have errors in the code, we log the error, but it uses line numbers from the output worker, which aren't helpful. Particularly because we don't output the actual worker to disk anyway, so they can't figure out where the error is coming from. It's really bad for large codebases.
+
+Figuring out debugging is a top level concern for us; we want to have sourcemaps, breakpoints, devtools - the works. But until we get there, we should help people find where errors are coming from.
+
+This adds an experimental `--unstable_outdir <path>` to `partykit dev` that spits out the actual code that we run in the dev environment, so folks can inspect it. The output code also inlines filenames, so that should help as well. This should hold folks until we have a better debugging story.

--- a/packages/partykit/src/bin.tsx
+++ b/packages/partykit/src/bin.tsx
@@ -100,6 +100,12 @@ program
   .argument("[script]", "Path to the project to run")
   .option("-p, --port <number>", "Port to run the server on")
   .option("--serve <path>", "Serve this directory of static assets")
+  .addOption(
+    new Option(
+      "--unstable_outdir <path>",
+      "Output directory for builds"
+    ).hideHelp()
+  )
   .option("-c, --config <path>", "Path to config file")
   .addOption(
     new Option("--persist [path]", "Persist local state").default(true)
@@ -121,6 +127,7 @@ program
     render(
       <Dev
         main={scriptPath}
+        unstable_outdir={options.unstable_outdir}
         port={options.port ? parseInt(options.port) : undefined}
         persist={options.persist}
         config={options.config}

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -221,6 +221,7 @@ export type DevProps = {
   persist?: boolean | string;
   vars?: Record<string, string>;
   verbose?: boolean;
+  unstable_outdir?: string;
   define?: Record<string, string>;
   onReady?: (host: string, port: number) => void;
   compatibilityDate?: string;
@@ -581,6 +582,7 @@ Workers["${name}"] = ${name};
         format: "esm",
         sourcemap: true,
         external: ["__STATIC_ASSETS_MANIFEST__"],
+        metafile: true,
         define: {
           PARTYKIT_HOST: `"127.0.0.1:${portForServer}"`,
           ...esbuildOptions.define,
@@ -610,6 +612,25 @@ Workers["${name}"] = ${name};
                 }
 
                 const code = result.outputFiles[0].text;
+
+                if (options.unstable_outdir) {
+                  const outdir = path.join(
+                    process.cwd(),
+                    options.unstable_outdir
+                  );
+
+                  fs.mkdirSync(outdir, { recursive: true });
+                  fs.writeFileSync(
+                    path.join(
+                      outdir,
+                      `${path.basename(
+                        absoluteScriptPath,
+                        path.extname(absoluteScriptPath)
+                      )}.js`
+                    ),
+                    code
+                  );
+                }
 
                 return new Promise<void>((resolve) => {
                   server.addEventListener("reloaded", () => resolve(), {
@@ -801,6 +822,7 @@ Workers["${name}"] = ${name};
     portForRuntimeInspector,
     options.config,
     options.verbose,
+    options.unstable_outdir,
   ]);
 
   const { onReady } = options;


### PR DESCRIPTION
When we have errors in the code, we log the error, but it uses line numbers from the output worker, which aren't helpful. Particularly because we don't output the actual worker to disk anyway, so they can't figure out where the error is coming from. It's really bad for large codebases.

Figuring out debugging is a top level concern for us; we want to have sourcemaps, breakpoints, devtools - the works. But until we get there, we should help people find where errors are coming from.

This adds an experimental `--unstable_outdir <path>` to `partykit dev` that spits out the actual code that we run in the dev environment, so folks can inspect it. The output code also inlines filenames, so that should help as well. This should hold folks until we have a better debugging story.