### PR TITLE
Fix compatibility date timezone

### DIFF
--- a/.changeset/ten-olives-joke.md
+++ b/.changeset/ten-olives-joke.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Fix compatibilityDate timezone issue, allow server to decide timezone if not provided

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -675,22 +675,16 @@ export const ${name} = ${name}Party;
   if (config.compatibilityDate) {
     form.set("compatibilityDate", config.compatibilityDate);
   } else {
-    const today = new Date();
-    const defaultCompatibilityDate = `${today.getFullYear()}-${(
-      today.getMonth() + 1
-    )
-      .toString()
-      .padStart(2, "0")}-${today.getDate().toString().padStart(2, "0")}`;
+    const currentUTCDate = new Date().toISOString().split("T", 1)[0];
 
     logger.warn(
-      `No compatibilityDate specified in configuration, defaulting to ${defaultCompatibilityDate}
+      `No compatibilityDate specified in configuration, defaulting to ${currentUTCDate}
 You can silence this warning by adding this to your partykit.json file: 
-  "compatibilityDate": "${defaultCompatibilityDate}"
+  "compatibilityDate": "${currentUTCDate}"
 or by passing it in via the CLI
-  --compatibility-date ${defaultCompatibilityDate}
+  --compatibility-date ${currentUTCDate}
 `
     );
-    form.set("compatibilityDate", defaultCompatibilityDate);
   }
   if (config.compatibilityFlags) {
     form.set("compatibilityFlags", JSON.stringify(config.compatibilityFlags));

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -502,20 +502,15 @@ function useDev(options: DevProps): {
   }
 
   useEffect(() => {
-    const today = new Date();
-    const latestCompatibilityDate = `${today.getFullYear()}-${(
-      today.getMonth() + 1
-    )
-      .toString()
-      .padStart(2, "0")}-${today.getDate().toString().padStart(2, "0")}`;
+    const currentUTCDate = new Date().toISOString().split("T", 1)[0];
 
     if (!config.compatibilityDate) {
       logger.warn(
-        `No compatibilityDate specified in configuration, defaulting to ${latestCompatibilityDate}
+        `No compatibilityDate specified in configuration, defaulting to ${currentUTCDate}
     You can silence this warning by adding this to your partykit.json file: 
-      "compatibilityDate": "${latestCompatibilityDate}"
+      "compatibilityDate": "${currentUTCDate}"
     or by passing it in via the CLI
-      --compatibility-date ${latestCompatibilityDate}`
+      --compatibility-date ${currentUTCDate}`
       );
     }
 
@@ -528,9 +523,7 @@ function useDev(options: DevProps): {
           new Date(require("workerd").compatibilityDate).getTime()
         )
       );
-      compatibilityDate = `${minDate.getFullYear()}-${(minDate.getMonth() + 1)
-        .toString()
-        .padStart(2, "0")}-${minDate.getDate().toString().padStart(2, "0")}`;
+      compatibilityDate = minDate.toISOString().split("T", 1)[0];
     } else {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       compatibilityDate = require("workerd").compatibilityDate;


### PR DESCRIPTION
- Uses UTC dates for dev mode timezone and the dev/deploy warnings
- Allows deployment platform to decide default date when one is not provided (do not send default date on deploy)