### PR TITLE
y-partykit: unstable_onRequest

### DIFF
--- a/.changeset/odd-meals-relate.md
+++ b/.changeset/odd-meals-relate.md
@@ -1,0 +1,22 @@
+---
+"y-partykit": patch
+---
+
+y-partykit: unstable_onRequest
+
+This adds an `unstable_onRequest` to `y-partykit`. Folks want to use http requests to prerender documents (during SSR, for example), and/or persist with an HTTP request.
+
+This is probably temporary while we rethink y-partykit all together.
+
+Usage:
+
+```ts
+import { onRequest } from "y-partykit";
+export default {
+  onRequest(req, room) {
+    return onRequest(req, room, {
+      /* options */
+    });
+  },
+};
+```

--- a/packages/y-partykit/src/index.ts
+++ b/packages/y-partykit/src/index.ts
@@ -474,3 +474,18 @@ export async function onConnect(
     }
   }
 }
+
+export async function unstable_onRequest(
+  _req: Request,
+  room: Party.Party,
+  options: YPartyKitOptions
+) {
+  const _doc = await getYDoc(room, options);
+
+  // if it's a POST, should we call options.callback here?
+
+  return new Response(
+    "document as json? or as a buffer?"
+    // we should send the response here
+  );
+}


### PR DESCRIPTION
This adds an `unstable_onRequest` to `y-partykit`. Folks want to use http requests to prerender documents (during SSR, for example), and/or persist with an HTTP request.

This is probably temporary while we rethink y-partykit all together.

Usage:

```ts
import { unstable_onRequest } from "y-partykit";
export default {
  onRequest(req, room) {
    return unstable_onRequest(req, room, {
      /* options */
    });
  },
};
```

// cc @wordware-ai