### PR TITLE
y-partykit: add onLoad callback

### DIFF
--- a/.changeset/calm-buckets-train.md
+++ b/.changeset/calm-buckets-train.md
@@ -1,0 +1,7 @@
+---
+"y-partykit": patch
+---
+
+y-partykit: add onLoad callback
+
+This adds an `onLoad` callback to `y-partykit`. While we can wait for onConnect to finish before we return, this doesn't give us a handle on the actual YDoc. This adds a callback that we can use to get a handle on the YDoc.

--- a/packages/y-partykit/src/index.ts
+++ b/packages/y-partykit/src/index.ts
@@ -380,6 +380,7 @@ export type YPartyKitOptions = {
   callback?: YPartyKitCallbackOptions;
   load?: () => Promise<Y.Doc>;
   readOnly?: boolean;
+  onLoad?: (doc: Y.Doc) => void;
 };
 
 export async function onConnect(
@@ -472,5 +473,8 @@ export async function onConnect(
       );
       send(doc, conn, encoding.toUint8Array(encoder));
     }
+  }
+  if (options.onLoad) {
+    options.onLoad(doc);
   }
 }


### PR DESCRIPTION
This adds an `onLoad` callback to `y-partykit`. While we can wait for onConnect to finish before we return, this doesn't give us a handle on the actual YDoc. This adds a callback that we can use to get a handle on the YDoc.