### PR TITLE
y-partykit: export `getYDoc`

### DIFF
--- a/.changeset/mighty-balloons-lie.md
+++ b/.changeset/mighty-balloons-lie.md
@@ -1,0 +1,15 @@
+---
+"y-partykit": patch
+---
+
+y-partykit: export `getYDoc`
+
+Directly get the `Y.Doc` instance
+
+```ts
+import { getYDoc } from "y-partykit";
+
+// ...
+
+const doc = await getYDoc(room, options);
+```

--- a/packages/y-partykit/src/index.ts
+++ b/packages/y-partykit/src/index.ts
@@ -148,7 +148,7 @@ function getContent(objName: string, objType: string, doc: WSSharedDoc) {
 /**
  * Gets a Y.Doc by name, whether in memory or on disk
  */
-async function getYDoc(
+export async function getYDoc(
   // docname: string, // the name of the Y.Doc to find or create
   room: Party.Party,
   options: YPartyKitOptions


### PR DESCRIPTION
Directly get the `Y.Doc` instance

```ts
import {getYDoc} from 'y-partykit';

// ...

const doc = await getYDoc(room, options)
```