### PR TITLE
y-partykit: remove ping-pong

### DIFF
--- a/.changeset/unlucky-squids-wink.md
+++ b/.changeset/unlucky-squids-wink.md
@@ -1,0 +1,7 @@
+---
+"y-partykit": patch
+---
+
+y-partykit: remove ping-pong
+
+We had a ping-pong loop with partykit to keep the object alive, but it's not necessary. This patch removes it.

--- a/packages/y-partykit/src/index.ts
+++ b/packages/y-partykit/src/index.ts
@@ -346,8 +346,6 @@ function send(doc: WSSharedDoc, conn: Party.Connection, m: Uint8Array) {
   }
 }
 
-const pingTimeout = 30000;
-
 interface CallbackOptions {
   debounceWait?: number;
   debounceMaxWait?: number;
@@ -424,33 +422,10 @@ export async function onConnect(
     }
   });
 
-  // Check if connection is still alive
-  let pongReceived = true;
-  const pingInterval = setInterval(() => {
-    if (!pongReceived) {
-      if (doc.conns.has(conn)) {
-        closeConn(doc, conn);
-      }
-      clearInterval(pingInterval);
-    } else if (doc.conns.has(conn)) {
-      pongReceived = false;
-      try {
-        conn.send("ping");
-      } catch (e) {
-        closeConn(doc, conn);
-        clearInterval(pingInterval);
-      }
-    }
-  }, pingTimeout);
   conn.addEventListener("close", () => {
     closeConn(doc, conn);
-    clearInterval(pingInterval);
   });
-  conn.addEventListener("message", (message) => {
-    if (message.data === "pong") {
-      pongReceived = true;
-    }
-  });
+
   // put the following in a variables in a block so the interval handlers don't keep in in
   // scope
   {

--- a/packages/y-partykit/src/provider.ts
+++ b/packages/y-partykit/src/provider.ts
@@ -134,10 +134,6 @@ function setupWS(provider: WebsocketProvider) {
     provider.synced = false;
 
     websocket.onmessage = (event) => {
-      if (event.data === "ping") {
-        websocket.send("pong");
-        return;
-      }
       if (typeof event.data === "string") {
         // ignore text messages
         return;


### PR DESCRIPTION
We had a ping-pong loop with partykit to keep the object alive, but it's not necessary. This patch removes it.