### PR TITLE
fix: .send and .broadcast can send ArrayBuffers

### DIFF
--- a/.changeset/four-actors-draw.md
+++ b/.changeset/four-actors-draw.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+fix: .send and .broadcast can send ArrayBuffers
+
+WebSocket messages can be `string | ArrayBuffer | ArrayBufferView`, this patch fixes the types to allow that. The implementation remains the same (and otherwise always worked).

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -275,7 +275,10 @@ function createDurable(
       };
     }
 
-    broadcast = (msg: string | Uint8Array, without: string[] = []) => {
+    broadcast = (
+      msg: string | ArrayBuffer | ArrayBufferView,
+      without: string[] = []
+    ) => {
       if (!this.connectionManager) {
         return;
       }
@@ -461,7 +464,10 @@ function createDurable(
     }
 
     /** Runtime calls webSocketMessage when hibernated connection receives a message  */
-    async webSocketMessage(ws: WebSocket, msg: string | ArrayBuffer) {
+    async webSocketMessage(
+      ws: WebSocket,
+      msg: string | ArrayBuffer | ArrayBufferView
+    ) {
       const connection = createLazyConnection(ws);
       if (!this.worker) {
         // This means the room "woke up" after hibernation
@@ -495,7 +501,7 @@ function createDurable(
 
     async invokeOnMessage(
       connection: Party.Connection,
-      msg: string | ArrayBuffer
+      msg: string | ArrayBuffer | ArrayBufferView
     ) {
       assert(this.worker, "[onMessage] Worker not initialized.");
       return this.worker.onMessage(msg, connection);

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -144,7 +144,10 @@ export type Party = {
   parties: Context["parties"];
 
   /** Send a message to all connected clients, except connection ids listed `without` */
-  broadcast: (msg: string, without?: string[] | undefined) => void;
+  broadcast: (
+    msg: string | ArrayBuffer | ArrayBufferView,
+    without?: string[] | undefined
+  ) => void;
 
   /** Get a connection by connection id */
   getConnection<TState = unknown>(id: string): Connection<TState> | undefined;
@@ -203,7 +206,7 @@ export type Server = {
    * Called when a WebSocket connection receives a message from a client, or another connected party.
    */
   onMessage?(
-    message: string | ArrayBuffer,
+    message: string | ArrayBuffer | ArrayBufferView,
     sender: Connection
   ): void | Promise<void>;
 
@@ -341,7 +344,7 @@ export type PartyKitServer = {
    * messages, which enables a single server to handle more connections.
    */
   onMessage?: (
-    message: string | ArrayBuffer,
+    message: string | ArrayBuffer | ArrayBufferView,
     connection: Connection,
     party: Party
   ) => void | Promise<void>;


### PR DESCRIPTION
WebSocket messages can be `string | ArrayBuffer | ArrayBufferView`, this patch fixes the types to allow that. The implementation remains the same (and otherwise always worked).