### PR TITLE
Allow passing PartySocket.query as a function

### DIFF
--- a/apps/docs/src/content/docs/guides/authentication.md
+++ b/apps/docs/src/content/docs/guides/authentication.md
@@ -23,17 +23,19 @@ Every PartyKit server accepts WebSocket connections by default.
 To ensure that only authorized users can connect to your server, you should pass a session token to the initial connection request. The most convenient way to do this is to pass the token as a query string parameter:
 
 ```ts
-// get an auth token using your authentication client library
-const token = getToken();
 const partySocket = new PartySocket({
   host: PARTYKIT_HOST,
   room: "room-id",
-  // pass the token to PartyKit in the query string
-  query: {
-    token,
-  },
+  // attach the token to PartyKit in the query string
+  query: async () => ({
+    // get an auth token using your authentication client library
+    token: await getToken()
+  })
 });
 ```
+
+The `query` parameter can an object of key-value pairs, or an (optionally) asynchronous
+function that returns one.
 
 You can then verify your user's identity in a `static onBeforeConnect` method:
 

--- a/apps/docs/src/content/docs/reference/partysocket-api.md
+++ b/apps/docs/src/content/docs/reference/partysocket-api.md
@@ -51,6 +51,11 @@ const ws = new PartySocket({
   // optionally, specify the party to connect to.
   // if not provided, will connect to the "main" party defined in partykit.json
   party: "main",
+
+  // optionally, pass an object of query string parameters to add to the request
+  query: async () => ({
+    token: await getAuthToken()
+  })
 });
 ```
 

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -148,7 +148,7 @@ export type Party = {
   ) => void;
 
   /** Get a connection by connection id */
-  getConnection<TState = unknown>(id: string): Connection<TState>;
+  getConnection<TState = unknown>(id: string): Connection<TState> | undefined;
 
   /**
    * Get all connections. Optionally, you can provide a tag to filter returned connections.

--- a/packages/partysocket/src/index.ts
+++ b/packages/partysocket/src/index.ts
@@ -82,7 +82,7 @@ export default class PartySocket extends ReconnectingWebSocket {
     const makeUrl = (query?: Params) =>
       `${baseUrl}?${new URLSearchParams({ ...query, _pk }).toString()}`;
 
-    // allow urls to be
+    // allow urls to be defined as functions
     const urlProvider =
       typeof query === "function"
         ? async () => makeUrl(await query())


### PR DESCRIPTION
This enables people to pass dynamic parameters such as authentication tokens upon reconnect.

As a side effect, we can no longer provide a static party `url`, so this is now available as `roomUrl`. `url` now reverts to the original base class behaviour, where it returns the dynamic url of the websocket (or an empty string if websocket is not yet initialized).

This is a breaking change, but AFAIK our only user of this behaviour is @jamesgpearce.