### PR TITLE
Allow passing a function to YPartyKitProvider options.params

### DIFF
--- a/.changeset/empty-kiwis-brush.md
+++ b/.changeset/empty-kiwis-brush.md
@@ -1,0 +1,5 @@
+---
+"y-partykit": patch
+---
+
+Allow passing a function to YPartyKitProvider options.params

--- a/apps/docs/src/content/docs/reference/y-partykit-api.md
+++ b/apps/docs/src/content/docs/reference/y-partykit-api.md
@@ -82,16 +82,21 @@ const provider = new YPartyKitProvider(
 
 You can add additional options to the provider:
 
-```ts
+```tsx
+
 // ...
+const getAuthToken = () => { /* ... */ };
 const provider = new YPartyKitProvider(
   "localhost:1999",
   "my-document-name",
   yDoc,
   {
     connect: false, // do not connect immediately, use provider.connect() when required
-    params: { token: "my-secret-token" }, // adds to the query string of the websocket connection
     awareness: new awarenessProtocol.Awareness(yDoc), // use your own Yjs awareness instance
+    // adds to the query string of the websocket connection, useful for e.g. auth tokens
+    params: async () => ({ 
+      token: await getAuthToken() 
+    });
   }
 );
 ```

--- a/examples/yjs/src/client.ts
+++ b/examples/yjs/src/client.ts
@@ -4,8 +4,22 @@ import * as Y from "yjs";
 declare const PARTYKIT_HOST: string;
 
 const doc = new Y.Doc();
+
+// example for attaching query string parameters to the request
+const getToken = (): Promise<Record<string, string>> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({ token: Date.now().toString() });
+    }, 100);
+  });
+};
+
 const provider = new YProvider(PARTYKIT_HOST, "yjs-demo", doc, {
   connect: false,
+  // disable broadcast channel for this demo, so syncing only happens via the partykit server
+  // https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API
+  disableBc: true,
+  params: getToken,
 });
 const yMessage: Y.Text = doc.getText("message");
 const awareness = provider.awareness;

--- a/packages/y-partykit/src/provider.ts
+++ b/packages/y-partykit/src/provider.ts
@@ -605,10 +605,10 @@ export default class YPartyKitProvider extends WebsocketProvider {
     }
   }
 
-  async connect() {
+  connect() {
     // get updated url parameters
     Promise.resolve(
-      typeof this.#params === "function" ? await this.#params() : this.#params
+      typeof this.#params === "function" ? this.#params() : this.#params
     )
       .then((nextParams) => {
         // override current url parameters before connecting

--- a/packages/y-partykit/src/provider.ts
+++ b/packages/y-partykit/src/provider.ts
@@ -607,16 +607,25 @@ export default class YPartyKitProvider extends WebsocketProvider {
 
   async connect() {
     // get updated url parameters
-    const params =
-      typeof this.#params === "function" ? await this.#params() : this.#params;
-    const nextUrl = new URL(this.url);
-    nextUrl.search = url.encodeQueryParams({
-      ...params,
-      _pk: this.id,
-    });
+    Promise.resolve(
+      typeof this.#params === "function" ? await this.#params() : this.#params
+    )
+      .then((nextParams) => {
+        // override current url parameters before connecting
+        const nextUrl = new URL(this.url);
+        nextUrl.search = url.encodeQueryParams({
+          ...nextParams,
+          _pk: this.id,
+        });
 
-    // override current url parameters before connecting
-    this.url = nextUrl.toString();
-    super.connect();
+        this.url = nextUrl.toString();
+
+        // finally, connect
+        super.connect();
+      })
+      .catch((err) => {
+        console.error("Failed to open connecton to PartyKit", err);
+        throw new Error(err);
+      });
   }
 }


### PR DESCRIPTION
Useful for e.g. passing authentication token and refreshing them on reconnect.