### PR TITLE
added missing crypto from node_compat

### DIFF
--- a/.changeset/violet-days-retire.md
+++ b/.changeset/violet-days-retire.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+added missing crypto from node_compat

--- a/packages/partykit/src/nodejs-compat.ts
+++ b/packages/partykit/src/nodejs-compat.ts
@@ -12,6 +12,7 @@ const supportedNodeBuiltins = [
   "stream",
   "string_decoder",
   "util",
+  "crypto"
 ];
 
 const plugin: Plugin = {


### PR DESCRIPTION
crypto was missing from the node_compat, and users can't use the node:crypto.

I've added it, & it works. well it works on my device 😂