### PR TITLE
Allow preflight requests when Chrome Private Network Access is enabled

### DIFF
--- a/.changeset/rude-bikes-agree.md
+++ b/.changeset/rude-bikes-agree.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Allow preflight requests when Chrome Private Network Access is enabled

--- a/packages/partykit/src/auth/device.ts
+++ b/packages/partykit/src/auth/device.ts
@@ -34,6 +34,9 @@ export async function signInWithBrowser(mode: "cli" | "token"): Promise<
         res.setHeader("Access-Control-Allow-Origin", "*");
         res.setHeader("Access-Control-Allow-Headers", "Authorization");
 
+        // https://developer.chrome.com/blog/private-network-access-preflight/
+        res.setHeader("Access-Control-Allow-Private-Network", "true");
+
         if (req.method === "OPTIONS") {
           res.statusCode = 204;
           res.end();


### PR DESCRIPTION
It seems Chrome is rolling out the new Private Network Access initiative that improves the security of making public websites (e.g. dashboard.partykit.io) to connect to private address spaces (e.g. the authentication callback server we spin up at localhost).

It's not 100% clear to me which way this initiative is going, but as per the [preflight specification](https://developer.chrome.com/blog/private-network-access-preflight/), we now respond with the correct headers to allow this variant of it.

According to the above blog post, this may not be sufficient in the long term, as they seem to be moving towards blocking public-private HTTP traffic entirely. Mitigations for that are described in https://developer.chrome.com/blog/private-network-access-update

This PR fixes known issue #471, and I'll follow up on the long-term changes in a separate PR.