### PR TITLE
pass sub path/init during subparty .fetch()/.socket()

### DIFF
--- a/.changeset/twelve-snails-suffer.md
+++ b/.changeset/twelve-snails-suffer.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+pass sub path/init during subparty .fetch()/.socket()
+
+This lets you pass a "sub" path to a sub party `.fetch()` or `.socket()` (and adds being able to pass a RequestInit to `.socket()`). This make it possible to do routing more cleanly inside sub parties, making them more versatile.

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -6,6 +6,8 @@ import type {
   DurableObjectNamespace,
   DurableObjectState,
   ExecutionContext,
+  RequestInfo,
+  RequestInit,
 } from "@cloudflare/workers-types";
 import fetchStaticAsset from "./fetch-static-asset";
 import {
@@ -81,7 +83,7 @@ function createMultiParties(
   options: {
     host: string;
   }
-) {
+): Party.Party["context"]["parties"] {
   if (!parties) {
     parties = {};
     for (const [key, value] of Object.entries(namespaces)) {
@@ -92,40 +94,96 @@ function createMultiParties(
             const id = value.idFromString(docId);
             const stub = value.get(id);
             return {
-              fetch(init?: RequestInit) {
-                return stub.fetch(
-                  key === "main"
-                    ? `http://${options.host}/party/${name}`
-                    : `http://${options.host}/parties/${key}/${name}`,
-                  init
-                );
+              fetch(
+                pathOrInit?: string | RequestInit,
+                maybeInit?: RequestInit
+              ) {
+                let path: RequestInfo | undefined;
+                let init: RequestInit | undefined;
+                if (pathOrInit) {
+                  if (typeof pathOrInit === "string") {
+                    path = pathOrInit;
+                    init = maybeInit;
+                    if (path[0] !== "/") {
+                      throw new Error("Path must start with /");
+                    }
+                    return stub.fetch(
+                      `http://${options.host}/parties/${key}/${name}${path}`,
+                      init
+                    );
+                  } else {
+                    init = pathOrInit;
+                    return stub.fetch(
+                      `http://${options.host}/parties/${key}/${name}`,
+                      init
+                    );
+                  }
+                } else {
+                  return stub.fetch(
+                    `http://${options.host}/parties/${key}/${name}`
+                  );
+                }
               },
               connect: () => {
                 return new WebSocket(
-                  key === "main"
-                    ? `ws://${options.host}/party/${name}`
-                    : `ws://${options.host}/parties/${key}/${name}`
+                  `ws://${options.host}/parties/${key}/${name}`
                 );
               },
-              async socket() {
+              async socket(
+                pathOrInit?: string | RequestInit,
+                maybeInit?: RequestInit
+              ) {
+                let res: Response;
                 // This method is better because it doesn't go via the internet
                 // and doesn't get 522/404/ get caught in CF firewall
-                const res = await stub.fetch(
-                  key === "main"
-                    ? `http://${options.host}/party/${name}`
-                    : `http://${options.host}/parties/${key}/${name}`,
-                  {
-                    headers: {
-                      upgrade: "websocket",
-                    },
+                let path: RequestInfo | undefined;
+                let init: RequestInit | undefined;
+                if (pathOrInit) {
+                  if (typeof pathOrInit === "string") {
+                    path = pathOrInit;
+                    init = maybeInit;
+                    if (path[0] !== "/") {
+                      throw new Error("Path must start with /");
+                    }
+                    res = await stub.fetch(
+                      `http://${options.host}/parties/${key}/${name}${path}`,
+                      {
+                        ...init,
+                        headers: {
+                          upgrade: "websocket",
+                          ...init?.headers,
+                        },
+                      }
+                    );
+                  } else {
+                    init = pathOrInit;
+                    res = await stub.fetch(
+                      `http://${options.host}/parties/${key}/${name}`,
+                      {
+                        ...init,
+                        headers: {
+                          upgrade: "websocket",
+                          ...init?.headers,
+                        },
+                      }
+                    );
                   }
-                );
+                } else {
+                  res = await stub.fetch(
+                    `http://${options.host}/parties/${key}/${name}`,
+                    {
+                      headers: {
+                        upgrade: "websocket",
+                      },
+                    }
+                  );
+                }
                 const ws = res.webSocket;
                 if (!ws) {
                   throw new Error("Expected a websocket response");
                 }
                 ws.accept();
-                return ws;
+                return ws as WebSocket;
               },
             };
           },

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -39,8 +39,14 @@ export type ConnectionContext = { request: CFRequest };
 export type Stub = {
   /** @deprecated Use `await socket()` instead */
   connect: () => WebSocket;
-  socket: () => Promise<WebSocket>;
-  fetch: (init?: RequestInit) => Promise<Response>;
+  socket: (
+    pathOrInit?: string | RequestInit,
+    maybeInit?: RequestInit
+  ) => Promise<WebSocket>;
+  fetch: (
+    pathOrInit?: string | RequestInit,
+    maybeInit?: RequestInit
+  ) => Promise<Response>;
 };
 
 /** Additional information about other resources in the current project */


### PR DESCRIPTION
This lets you pass a "sub" path to a sub party `.fetch()` or `.socket()` (and adds being able to pass a RequestInit to `.socket()`). This make it possible to do routing more cleanly inside sub parties, making them more versatile.

--- 

This does NOT expose the "sub" path inside the party. It might make this more useful, but it's not clear where to expose it yet.
This does NOT accept URLs or Requests as the first parameter yet. 

 I also want to do some more testing on this, but opening it up for a review. 
