### PR TITLE
[PROPOSAL] y-partykit storage modes

### DIFF
--- a/apps/docs/src/content/docs/reference/y-partykit-api.md
+++ b/apps/docs/src/content/docs/reference/y-partykit-api.md
@@ -7,7 +7,7 @@ sidebar:
 
 `y-partykit` is an addon library for `partykit` designed to host backends for [Yjs](https://yjs.dev), a high-performance library of data structures for building collaborative software.
 
-## Setting up a Yjs backend
+## Setting up a Yjs Server
 
 Using `y-partykit` simplifies setting up a Yjs backend. Only a few lines of code are needed:
 
@@ -19,53 +19,18 @@ import { onConnect } from "y-partykit";
 export default class YjsServer implements Party.Server {
   constructor(public party: Party.Party) {}
   onConnect(conn: Party.Connection) {
-    return onConnect(conn, this.party);
-  }
-}
-```
-
-## Handling more complex backends
-
-For more complex backends, you can pass additional options:
-
-```ts
-// server.ts
-
-import type * as Party from "partykit/server";
-import { onConnect } from "y-partykit";
-
-export default class YjsServer implements Party.Server {
-  constructor(public party: Party.Party) {}
-  onConnect(conn: Party.Connection) {
     return onConnect(conn, this.party, {
-      // experimental: persists the document to partykit's room storage
-      persist: true,
-
-      // enable read only access to true to disable editing, default: false
-      readOnly: true,
-
-      // Or, you can load/save to your own database or storage
-      async load() {
-        // load a document from a database, or some remote resource
-        // and return a Y.Doc instance here (or null if no document exists)
-      },
-      callback: {
-        async handler(yDoc) {
-          // called every few seconds after edits
-          // you can use this to write to a database
-          // or some external storage
-        },
-        // control how often handler is called with these options
-        debounceWait: 10000, // default: 2000 ms
-        debounceMaxWait: 20000, // default: 10000 ms
-        timeout: 5000, // default: 5000 ms
-      },
+      // ...options
     });
   }
 }
 ```
 
-Then, use the provider to connect to this server from your client:
+See [Server Configuration](#server-configuration) for configuration options.
+
+## Connecting from the client
+
+Use the provider to connect to this server from your client:
 
 ```ts
 import YPartyKitProvider from "y-partykit/provider";
@@ -117,6 +82,146 @@ function App() {
   });
 }
 ```
+
+
+## Server Configuration
+
+For more complex backends, you can pass additional options.
+
+```ts
+// server.ts
+import type * as Party from "partykit/server";
+import { onConnect } from "y-partykit";
+
+export default class YjsServer implements Party.Server {
+  constructor(public party: Party.Party) {}
+  onConnect(conn: Party.Connection) {
+    return onConnect(conn, this.party, {
+      // experimental: persists the document to partykit's room storage
+      persist: { mode: "snapshot" },
+
+      // enable read only access to true to disable editing, default: false
+      readOnly: true,
+
+      // Or, you can load/save to your own database or storage
+      async load() {
+        // load a document from a database, or some remote resource
+        // and return a Y.Doc instance here (or null if no document exists)
+      },
+
+      callback: {
+        async handler(yDoc) {
+          // called every few seconds after edits
+          // you can use this to write to a database
+          // or some external storage
+        },
+        // control how often handler is called with these options
+        debounceWait: 10000, // default: 2000 ms
+        debounceMaxWait: 20000, // default: 10000 ms
+        timeout: 5000, // default: 5000 ms
+      },
+    });
+  }
+}
+```
+
+
+### Persistence
+
+By default, PartyKit maintains a copy of the Yjs document as long as at least one client is connected to the server. When all clients disconnect, the document state may be lost.
+
+To persists the Yjs document state, you can use the built-in PartyKit room storage by enabling the `persist` option. 
+
+`y-partykit` supports two modes of persistence: **snapshots**, and **history**.
+
+#### Persisting snapshots (recommended)
+
+In `snapshot` mode, PartyKit stores the latest document state between sessions. 
+
+```ts
+onConnect(connection, party, {
+  persist: { 
+    mode: "snapshot" 
+  }
+})
+```
+
+During a session, PartyKit accumulates individual updates and stores them as separate records. When an editing session ends due to last connection disconnecting, PartyKit merges all updates to a single snapshot.
+
+The `snapshot` mode is optimal for most applications that do not need to support long-lived offline editing sessions.
+
+#### Persisting update history (advanced)
+
+In `history` mode, PartyKit stores the full edit history of the document.
+
+This is useful when multiple clients are expected to be able to work while offline, and synchronise their changes later.
+
+```ts
+onConnect(connection, party, {
+  persist: { 
+    mode: "history",
+  }
+})
+```
+
+For long-lived documents, the edit history would grow indefinitely, eventually reaching the practical limits of a single PartyKit server instance.
+
+To prevent unbounded growth, PartyKit applies a 10MB maximum limit to the edit history. You can customise these limits as follows:
+
+```ts
+onConnect(connection, party, {
+  persist: { 
+    mode: "history",
+    // Maximum size in bytes. 
+    // You can set this value to any number 10MB (10_000_000 bytes).
+    maxBytes: 10_000_000,
+
+    // Maximum number of updates. 
+    // By default, there is no maximum, and history grows until maximum amount of bytes is reached.
+    maxUpdates: 10_000,
+  }
+})
+```
+
+Once either limit is reached, the document is snapshotted, and history tracking is started again.
+
+#### `persist: true` (deprecated)
+
+In previous versions, PartyKit only had one persistence mode:
+
+```ts
+onConnect(connection, party, {
+  persist: true
+})
+```
+
+This is equivalent to setting the value to `{ mode: "history" }`, but you will see a warning.
+
+This option is still supported for backwards compatibility reasons, but will be removed in a future version of `y-partykit`. 
+
+#### Persisting to an external service
+
+You can use a combination of the `load` and `callback` options to synchronise the document to an external service:
+
+```ts
+return onConnect(conn, this.party, {
+  async load() {
+    return await fetchDataFromExternalService();
+  },
+
+  callback: {
+    async handler(yDoc) {
+      return sendDataToExternalService(yDoc);
+    },
+    // only save after every 2 seconds (default)
+    debounceWait: 2000,
+    // if updates keep coming, save at least once every 10 seconds (default)
+    debounceMaxWait: 10000
+  }
+});
+```
+
+The `load` callback is called on first connection to the server instance. Once the document has been loaded, it's kept in memory until the session ends.
 
 ## Learn more
 

--- a/apps/docs/src/content/docs/reference/y-partykit-api.md
+++ b/apps/docs/src/content/docs/reference/y-partykit-api.md
@@ -130,9 +130,9 @@ export default class YjsServer implements Party.Server {
 
 By default, PartyKit maintains a copy of the Yjs document as long as at least one client is connected to the server. When all clients disconnect, the document state may be lost.
 
-To persists the Yjs document state, you can use the built-in PartyKit room storage by enabling the `persist` option. 
+To persists the Yjs document state between sessions, you can use the built-in PartyKit storage by enabling the `persist` option. 
 
-`y-partykit` supports two modes of persistence: **snapshots**, and **history**.
+`y-partykit` supports two modes of persistence: **snapshot**, and **history**.
 
 #### Persisting snapshots (recommended)
 
@@ -154,7 +154,7 @@ The `snapshot` mode is optimal for most applications that do not need to support
 
 In `history` mode, PartyKit stores the full edit history of the document.
 
-This is useful when multiple clients are expected to be able to work while offline, and synchronise their changes later.
+This is useful when multiple clients are expected to be able to change the document while offline, and synchronise their changes later.
 
 ```ts
 onConnect(connection, party, {
@@ -190,12 +190,10 @@ Once either limit is reached, the document is snapshotted, and history tracking 
 In previous versions, PartyKit only had one persistence mode:
 
 ```ts
-onConnect(connection, party, {
-  persist: true
-})
+onConnect(connection, party, { persist: true })
 ```
 
-This is equivalent to setting the value to `{ mode: "history" }`, but you will see a warning.
+This is functionally equivalent to setting the value to `{ mode: "history" }`.
 
 This option is still supported for backwards compatibility reasons, but will be removed in a future version of `y-partykit`. 
 

--- a/packages/y-partykit/src/index.ts
+++ b/packages/y-partykit/src/index.ts
@@ -483,7 +483,7 @@ export type YPartyKitPersistenceStrategy =
 
 export type YPartyKitOptions = {
   /**
-   * disable gc when using persist or persistStrategy!
+   * disable gc when using persist!
    * */
   gc?: boolean;
 

--- a/packages/y-partykit/src/storage.ts
+++ b/packages/y-partykit/src/storage.ts
@@ -18,9 +18,9 @@ import {
 
 import type * as Party from "partykit/server";
 
-const PREFERRED_TRIM_SIZE = 300;
-
 const BINARY_BITS_32 = 0xffffffff;
+const TRACE_ENABLED = false;
+const trace = (...args: unknown[]) => TRACE_ENABLED && console.log(...args);
 
 type StorageKey = DocumentStateVectorKey | DocumentUpdateKey;
 
@@ -461,24 +461,41 @@ export class YPartyKitStorage {
     return this._transact(async (db) => {
       const updates = await getLevelUpdates(db, docName);
       const flush = async () => {
+        trace("[compactUpdateLog]", "Compacting document update log!");
         const { update, sv } = mergeUpdates(updates.map((u) => u.value));
+
         await flushDocument(db, docName, update, sv);
       };
 
+      trace("[compactUpdateLog]", { docName, maxUpdates, maxBytes });
+      trace("[compactUpdateLog]", "Current update count:", updates.length);
+
       // total number of updates is too large -> flush
-      if (!maxUpdates || updates.length > maxUpdates) {
+      if (updates.length > maxUpdates) {
+        trace(
+          "[compactUpdateLog]",
+          `Update count exceeds maximum allowed: ${updates.length} > ${maxUpdates}`
+        );
         return flush();
       }
 
-      // total update log size is too large -> flush
-      if (
-        !maxBytes ||
-        updates.reduce((size, u) => size + u.value.byteLength, 0) > maxBytes
-      ) {
+      const totalBytes = updates.reduce(
+        (size, u) => size + u.value.byteLength,
+        0
+      );
+      trace("[compactUpdateLog]", "Current update size:", totalBytes);
+
+      // total update log size is too large -> flush (unless it's already a single update)
+      if (totalBytes > maxBytes && updates.length > 1) {
+        trace(
+          "[compactUpdateLog]",
+          `Update total size exceeds maximum allowed: ${totalBytes} > ${maxBytes}`
+        );
         return flush();
       }
 
       // no need to flush
+      trace("[compactUpdateLog]", "Skipping compacting update log...");
       return Promise.resolve();
     });
   }
@@ -492,14 +509,7 @@ export class YPartyKitStorage {
           applyUpdate(ydoc, updates[i].value);
         }
       });
-      if (updates.length > PREFERRED_TRIM_SIZE) {
-        await flushDocument(
-          db,
-          docName,
-          encodeStateAsUpdate(ydoc),
-          encodeStateVector(ydoc)
-        );
-      }
+
       return ydoc;
     });
   }


### PR DESCRIPTION
Adds options to control how to persist the document to PartyKit room storage.

The goal here is to not break existing clients, and provide a migration path to more sensible strategies.

 - `{mode: "snapshot"}` — persist full document snapshot (recommended)
 - `{mode: "history", maxUpdates, maxBytes }` — persist document edit history
 - `true` — Equivalent to `{ mode: "history" }` (deprecated, use `{ mode: "history "}` instead)
 - `false` — Do not persist document or history (default value)

See diff for better options.