### PR TITLE
don't mark react as a dependency for partysocket

### DIFF
--- a/.changeset/few-owls-wait.md
+++ b/.changeset/few-owls-wait.md
@@ -1,0 +1,7 @@
+---
+"partysocket": patch
+---
+
+don't mark react as a dependency for partysocket
+
+This dependency causes way too many issues, especially since react doesn't work with multiple versions. Let's see if removing it helps.

--- a/packages/partysocket/package.json
+++ b/packages/partysocket/package.json
@@ -39,9 +39,6 @@
     ],
     "dts": true
   },
-  "optionalDependencies": {
-    "react": "^18.2.0"
-  },
   "scripts": {
     "clean": "shx rm -rf dist *.d.ts",
     "post-build": "shx mv dist/*.d.ts* .",


### PR DESCRIPTION
This dependency causes way too many issues, especially since react doesn't work with multiple versions. Let's see if removing it helps.