### PR TITLE
partysocket: don't bundle react into the built assets

### DIFF
--- a/.changeset/tidy-olives-pretend.md
+++ b/.changeset/tidy-olives-pretend.md
@@ -1,0 +1,7 @@
+---
+"partysocket": patch
+---
+
+partysocket: don't bundle react into the built assets
+
+tsup ignores pnly dependencies marked in package.json under dependencies/devDependencies. Since we don't have react in here, it was bundling it into partysocket/react, leading to multiple versions being loaded into the same space. This explicity excludes react from the bundle.

--- a/packages/partysocket/package.json
+++ b/packages/partysocket/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "clean": "shx rm -rf dist *.d.ts",
     "post-build": "shx mv dist/*.d.ts* .",
-    "build": "npm run clean && tsup && npm run post-build",
+    "build": "npm run clean && tsup --external react && npm run post-build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "files": [


### PR DESCRIPTION
tsup ignores pnly dependencies marked in package.json under dependencies/devDependencies. Since we don't have react in here, it was bundling it into partysocket/react, leading to multiple versions being loaded into the same space. This explicity excludes react from the bundle.