### PR TITLE
deletes 404 shrug

### DIFF
--- a/apps/blog/src/pages/404.astro
+++ b/apps/blog/src/pages/404.astro
@@ -12,8 +12,7 @@ import LinkButton from "@components/LinkButton.astro";
   <main id="main-content">
     <div class="not-found-wrapper">
       <h1 aria-label="404 Not Found">404</h1>
-      <span aria-hidden="true">¯\_(ツ)_/¯</span>
-      <p>Page Not Found</p>
+      <p>Page Not Found 💔</p>
       <LinkButton
         href="/"
         className="my-6 underline decoration-dashed underline-offset-8 text-lg"


### PR DESCRIPTION
I've been really not enjoying the 404 page on the blog because the shrug feels like we don't care.

<img width="627" alt="Screenshot 2023-10-12 at 9 14 21 PM" src="https://github.com/partykit/partykit/assets/45401242/a493b86e-1972-49db-acee-e327e375fd97">

before we design one 404 page across all sites, I just deleted the shrug.