### PR TITLE
partysocket: add subpath support

### DIFF
--- a/.changeset/heavy-mails-raise.md
+++ b/.changeset/heavy-mails-raise.md
@@ -1,0 +1,7 @@
+---
+"partysocket": patch
+---
+
+partysocket: add subpath support
+
+This patch lets you add `path: string` to `new PartySocket({...})` and point to a subpath in a room. This is a client side analog to the recent subpath support we added to multiparty `.fetch()`/`.socket()`


### PR DESCRIPTION
This patch lets you add `path: string` to `new PartySocket({...})` and point to a subpath in a room. This is a client side analog to the recent subpath support we added to multiparty `.fetch()`/`.socket()`