### PR TITLE
DO NOT LAND partykit: adds more hibernatable socket methods

### DIFF
--- a/.changeset/orange-eels-happen.md
+++ b/.changeset/orange-eels-happen.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+partykit: adds more hibernatable socket methods
+
+This adds the missing methods that we can use to respond to messages when objects are hibernated without waking up the object. Namely, setWebSocketAutoResponse, getWebSocketAutoResponse, and getWebSocketAutoResponseTimestamp. Details in type signature, more info here: https://developers.cloudflare.com/durable-objects/api/websockets/#setwebsocketautoresponse

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -349,6 +349,29 @@ function createDurable(
           );
           return this.context.parties;
         },
+
+        setWebSocketAutoResponse(req?: string, res?: string) {
+          if (req && res) {
+            return self.controller.setWebSocketAutoResponse(
+              new WebSocketRequestResponsePair(req, res)
+            );
+          } else {
+            if (req || res) {
+              throw new Error(
+                "You must provide either both a request and response, or nothing, to setWebSocketAutoResponse"
+              );
+            }
+            return self.controller.setWebSocketAutoResponse(undefined);
+          }
+        },
+
+        getWebSocketAutoResponse() {
+          return self.controller.getWebSocketAutoResponse();
+        },
+
+        getWebSocketAutoResponseTimestamp(conn: Party.Connection) {
+          return self.controller.getWebSocketAutoResponseTimestamp(conn);
+        },
       };
     }
 

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -3,6 +3,7 @@ import type {
   ExecutionContext as CFExecutionContext,
   WebSocket,
   Request as CFRequest,
+  WebSocketRequestResponsePair,
 } from "@cloudflare/workers-types";
 
 export type StaticAssetsManifestType = {
@@ -163,6 +164,27 @@ export type Party = {
    * Use `Party.Server#getConnectionTags` to tag the connection on connect.
    */
   getConnections<TState = unknown>(tag?: string): Iterable<Connection<TState>>;
+
+  /**
+   * Sets an application level auto response that does not wake hibernated WebSockets.
+   * `party.setWebSocketAutoResponse` receives `(request, response)`
+   * as an argument, enabling any WebSocket that was accepted in hibernation mode
+   * to automatically reply with response when it receives the specified request.
+   * More: https://developers.cloudflare.com/durable-objects/api/websockets/#setwebsocketautoresponse
+   */
+  setWebSocketAutoResponse: (request: string, response: string) => void;
+  /**
+   * Gets the `WebSocketRequestResponsePair(request, response)` currently set,
+   * or `null` if there is none.
+   * More: https://developers.cloudflare.com/durable-objects/api/websockets/#getwebsocketautoresponse
+   */
+  getWebSocketAutoResponse: () => WebSocketRequestResponsePair | null;
+  /**
+   * Gets the most recent Date when the Connection received an auto-response request,
+   * or null if the given WebSocket never received an auto-response request.
+   * More: https://developers.cloudflare.com/durable-objects/api/websockets/#getwebsocketautoresponsetimestamp
+   */
+  getWebSocketAutoResponseTimestamp: (connection: Connection) => Date | null;
 };
 
 /* Party.Server defines what happens when someone connects to and sends messages or HTTP requests to your party


### PR DESCRIPTION
This adds the missing methods that we can use to respond to messages when objects are hibernated without waking up the object. Namely, setWebSocketAutoResponse, getWebSocketAutoResponse, and getWebSocketAutoResponseTimestamp. Details in type signature, more info here: https://developers.cloudflare.com/durable-objects/api/websockets/#setwebsocketautoresponse