### PR TITLE
fix: get proper room id from `/party/:id/*`

### DIFF
--- a/.changeset/nine-jobs-mate.md
+++ b/.changeset/nine-jobs-mate.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+fix: get proper room id from `/party/:id/*`
+
+We had a bug when picking out the room name from `/party/:id/*`, it would pick the whole subpath instead. This fixes it.

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -35,10 +35,10 @@ function getRoomAndPartyFromPathname(pathname: string): {
   room: string;
   party: string;
 } | null {
+  // NOTE: keep in sync with ./source.ts
   // TODO: use a URLPattern here instead
-  // TODO: might want to introduce a real router too
   if (pathname.startsWith("/party/")) {
-    const [_, roomId] = pathname.split("/party/");
+    const [_, __, roomId] = pathname.split("/");
     return {
       room: roomId,
       party: "main",


### PR DESCRIPTION
We had a bug when picking out the room name from `/party/:id/*`, it would pick the whole subpath instead. This fixes it.