### PR TITLE
splits Quickstart pages to two, reorders sidebar

### DIFF
--- a/apps/docs/.astro/types.d.ts
+++ b/apps/docs/.astro/types.d.ts
@@ -198,6 +198,13 @@ declare module 'astro:content' {
 
 	type ContentEntryMap = {
 		"docs": {
+"add-to-existing-project.md": {
+	id: "add-to-existing-project.md";
+  slug: "add-to-existing-project";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
 "enterprise.md": {
 	id: "enterprise.md";
   slug: "enterprise";

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -38,12 +38,17 @@ export default defineConfig({
             label: "Get Started",
             items: [
               {
+                label: "Quickstart",
+                link: "/quickstart/",
+              },
+              {
                 label: "What is PartyKit",
                 link: "/",
               },
               {
-                label: "Quickstart",
-                link: "/quickstart/",
+                label: "Add to existing project",
+                badge: "New",
+                link: "/add-to-existing-project/",
               },
               {
                 label: "How PartyKit works",

--- a/apps/docs/src/content/docs/add-to-existing-project.md
+++ b/apps/docs/src/content/docs/add-to-existing-project.md
@@ -38,7 +38,7 @@ Add desired behavior to your server, and connect it to the UI.
 Lastly, deploy your PartyKit server:
 
 ```bash
-npm partykit deploy
+npx partykit deploy
 ```
 
 To read more about deploying PartyKit server, check <a href="/guides/deploying-your-partykit-server/" target="_blank" rel="noopener noreferrer">our deployment guide</a>.

--- a/apps/docs/src/content/docs/add-to-existing-project.md
+++ b/apps/docs/src/content/docs/add-to-existing-project.md
@@ -1,0 +1,56 @@
+---
+title: Add PartyKit to existing project
+description: Bring realtime collaboration to your app with PartyKit
+---
+
+Follow this quick guide to add PartyKit to your existing app, and deploy it in just a few minutes.
+
+:::tip[Prefer a tutorial?]
+If you'd prefer an in-depth walkthrough, consider following our [tutorial](/tutorials/add-partykit-to-a-nextjs-app).
+:::
+
+Note that to run PartyKit, you need to have Node v. 17 or higher installed.
+
+### Add PartyKit to an existing app
+
+Add PartyKit to your existing project using the following command in the project's root directory:
+
+```bash
+npx partykit@latest init
+```
+
+This command installed two packages (<a href="/reference/partyserver-api/" target="_blank" rel="noopener noreferrer"><code>partykit</code></a> and <a href="/reference/partykit-cli/" target="_blank" rel="noopener noreferrer"><code>partysocket</code></a>) and added the `party` directory with a server template.
+
+## Run a dev server
+
+Run the following command in your terminal in your project's directory to start the dev server:
+
+```bash
+npx partykit dev
+```
+
+## Develop your server further
+
+Add desired behavior to your server, and connect it to the UI.
+
+## Deploy your app
+
+Lastly, deploy your PartyKit server:
+
+```bash
+npm partykit deploy
+```
+
+To read more about deploying PartyKit server, check <a href="/guides/deploying-your-partykit-server/" target="_blank" rel="noopener noreferrer">our deployment guide</a>.
+
+:::note
+Custom domains will be available in the near future.
+:::
+
+## Enjoy 🎈
+
+Welcome to the party, pal!
+
+---
+
+Questions? Ideas? We'd love to hear from you 🎈 Reach out to us on [Discord](https://discord.gg/KDZb7J4uxJ) or [Twitter](https://twitter.com/partykit_io)!

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -56,6 +56,7 @@ Share your PartyKit projects with us - and your friends 🥳
 ## Learn more
 
 - Dive deep in [How PartyKit works](/how-partykit-works)
+- Follow our [tutorials](/tutorials)
 - Read PartyKit [API Reference](/reference)
 - Explore our [Guides](/guides) and [Examples](/examples)
 - Watch Sunil Pai's talk <a href="https://www.youtube.com/watch?v=wd8QTRjZZaE" target="_blank" rel="noopener noreferrer">'Everything is better with friends'</a> from React Miami 2023 

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -35,23 +35,27 @@ PartyKit is a technology for realtime multiplayer collaborative applications. Ex
 - game development
 - long-running agentive AI bots
 
-**Are you using PartyKit?** We want to hear from you! Share your project with us on  [Discord](https://discord.gg/KDZb7J4uxJ) or [Twitter](https://twitter.com/partykit_io)!
+**Are you using PartyKit?** We want to hear from you! Share your project with us on <a href="https://discord.gg/KDZb7J4uxJ" target="_blank" rel="noopener noreferrer">Discord</a> or <a href="https://twitter.com/partykit_io" target="_blank" rel="noopener noreferrer">Twitter</a>!
 
 ## Who's using PartyKit?
 
-- [BlockNote](https://www.blocknotejs.org/), an open source block-based rich text editor - see PartyKit in action on their homepage
-- [tldraw](https://tldraw.com/), a collaborative digital whiteboard where PartyKit powers the collaborative whiteboard experience
-- [Stately](https://stately.ai/), a suite of visual tools for building app logic, which uses PartyKit to run state machines on the edge
+- <a href="https://www.blocknotejs.org/" target="_blank" rel="noopener noreferrer">BlockNote</a>, an open source block-based rich text editor - see PartyKit in action on their homepage
+- <a href="https://tldraw.com/" target="_blank" rel="noopener noreferrer">tldraw</a>, a collaborative digital whiteboard where PartyKit powers the collaborative whiteboard experience
+- <a href="https://stately.ai/" target="_blank" rel="noopener noreferrer">Stately</a>, a suite of visual tools for building app logic, which uses PartyKit to run state machines on the edge
+- <a href="https://www.epicweb.dev/" target="_blank" rel="noopener noreferrer">Kent C. Dodds</a>, a leading web dev educator uses PartyKit to power live avatars on his course platform (read our blog post <a href="https://blog.partykit.io/posts/partykit-powers-realtime-avatars-in-epic-web/" target="_blank" rel="noopener noreferrer">about Epic Web</a>)
+- <a href="https://viteconf.org/23/replay/vite_keynote" target="_blank" rel="noopener noreferrer">ViteConf</a>, an online-first conference celebrating Vite community implemented live reactions with PartyKit (read our blog post <a href="https://blog.partykit.io/posts/partykit-at-viteconf" target="_blank" rel="noopener noreferrer">about ViteConf</a>)
+- <a href="https://sitegpt.ai/" target="_blank" rel="noopener noreferrer">SiteGPT</a> where PartyKit powers an AI agent
+
 
 ## Get involved
 
 Share your PartyKit projects with us - and your friends 🥳
-- Join our community on [Discord](https://discord.gg/KDZb7J4uxJ)!
-- Reach out to us on [Twitter](https://twitter.com/partykit_io)!
+- Join our community on <a href="https://discord.gg/KDZb7J4uxJ" target="_blank" rel="noopener noreferrer">Discord</a>!
+- Reach out to us on <a href="https://twitter.com/partykit_io" target="_blank" rel="noopener noreferrer">Twitter</a>!
 
 ## Learn more
 
 - Dive deep in [How PartyKit works](/how-partykit-works)
 - Read PartyKit [API Reference](/reference)
 - Explore our [Guides](/guides) and [Examples](/examples)
-- Watch Sunil Pai's talk ['Everything is better with friends'](https://www.youtube.com/watch?v=wd8QTRjZZaE) from React Miami 2023 
+- Watch Sunil Pai's talk <a href="https://www.youtube.com/watch?v=wd8QTRjZZaE" target="_blank" rel="noopener noreferrer">'Everything is better with friends'</a> from React Miami 2023 

--- a/apps/docs/src/content/docs/quickstart.md
+++ b/apps/docs/src/content/docs/quickstart.md
@@ -36,7 +36,7 @@ Once the server is running, open localhost with the designated port (defaulting 
 Next, deploy your PartyKit server:
 
 ```bash
-npm partykit deploy
+npx partykit deploy
 ```
 
 To read more about deploying PartyKit apps, check <a href="/guides/deploying-your-partykit-server/" target="_blank" rel="noopener noreferrer">our guide</a>.

--- a/apps/docs/src/content/docs/quickstart.md
+++ b/apps/docs/src/content/docs/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Bring realtime collaboration to your app with PartyKit
+description: Build a collaborative realtime application with PartyKit
 ---
 
 Follow this quickstart guide to create and deploy your first PartyKit app in just a few minutes.
@@ -21,14 +21,6 @@ To create a PartyKit project faster, you can pass arguments to the `create` comm
 
 That's it! Navigate to your project's directory, and explore your first PartyKit app 🥳
 
-### Add PartyKit to an existing app
-
-Alternatively, you can add PartyKit to your existing project using the following command in the project's root directory:
-
-```bash
-npx partykit@latest init
-```
-
 ## Run a dev server
 
 To see PartyKit in action, run the following command in your terminal in your project's directory:
@@ -41,15 +33,13 @@ Once the server is running, open localhost with the designated port (defaulting 
 
 ## Deploy your app
 
-To deploy your app, run the following command in your terminal in your project's directory:
+Next, deploy your PartyKit server:
 
 ```bash
-npx partykit deploy
+npm partykit deploy
 ```
 
-If you're running PartyKit for the first time, you will be prompted to log in using GitHub. A new browser window will open with a device activation page where you can paste the code that was automatically copied to your clipboard from the terminal output.
-
-Next, you will be asked to grant permissions to PartyKit. Once you do that, your app will be deployed to your `partykit.dev` domain, which will follow the pattern of `[your project's name].[your GitHub username].partykit.dev`.
+To read more about deploying PartyKit apps, check <a href="/guides/deploying-your-partykit-server/" target="_blank" rel="noopener noreferrer">our guide</a>.
 
 After the domain has been provisioned (up to two minutes), **share the link with your friends and play with it live** 🥳
 


### PR DESCRIPTION
This PR:

- refreshes the content on "What is PartyKit"
- fixes an error in the content around running dev server (the experience is not the same for the new app, and when adding PartyKit to an existing app)
- updates the content around deployment
- rearranges the "Get Started" section so folks can faster get going