### PR TITLE
Fix broken links 

### DIFF
--- a/apps/docs/src/content/docs/examples/app-examples/falling-sand-game-three-js.md
+++ b/apps/docs/src/content/docs/examples/app-examples/falling-sand-game-three-js.md
@@ -16,4 +16,4 @@ Made by [Brian Jordan](https://twitter.com/bcjordan)
 Explore this example:
 
 - [GitHub repository](https://github.com/bcjordan/falling-sand-partykit)
-- [live demo](sand.graphics)
+- [live demo](https://sand.graphics)

--- a/apps/docs/src/content/docs/examples/app-examples/youtube-watch-party.md
+++ b/apps/docs/src/content/docs/examples/app-examples/youtube-watch-party.md
@@ -12,4 +12,4 @@ A YouTube watch party with a live chat by [Matt Webb](https://twitter.com/genmon
 Explore this example:
 
 - [GitHub repository](https://github.com/partykit/sketch-youtube)
-- [live demo](https://youtube-party-seven.vercel.app/)
+- [live demo](https://waterhole.genmon.partykit.dev/)


### PR DESCRIPTION
This PR fixed a few broken links.

- In the sand-game, without the https:// for sand.graphics, it became a relative link I guess linking to https://docs.partykit.io/examples/app-examples/falling-sand-game-three-js/sand.graphics. 

- The youtube watch party link 404ed, so updated it to link to the live demo of *Namib Desert, watering hole livestream* example demo.

Thank you.