### PR TITLE
Improvements to usePartySocket (and useWebSocket) reliability

### DIFF
--- a/.changeset/friendly-otters-fix.md
+++ b/.changeset/friendly-otters-fix.md
@@ -1,0 +1,5 @@
+---
+"partysocket": patch
+---
+
+Improvements to usePartySocket and useWebSocket hook reliability

--- a/packages/partysocket/src/react.ts
+++ b/packages/partysocket/src/react.ts
@@ -24,6 +24,7 @@ export default function usePartySocket(options: UsePartySocketOptions) {
         options.query,
         options.id,
         options.host,
+        options.room,
         options.party,
         options.path,
         options.protocol,

--- a/packages/partysocket/src/react.ts
+++ b/packages/partysocket/src/react.ts
@@ -1,13 +1,35 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useMemo, useState } from "react";
 import type { PartySocketOptions } from ".";
 import PartySocket from ".";
 import useWebSocketImpl from "./use-ws";
 
-type UsePartySocketOptions = PartySocketOptions & {
+type EventHandlerOptions = {
   onOpen?: (event: WebSocketEventMap["open"]) => void;
   onMessage?: (event: WebSocketEventMap["message"]) => void;
   onClose?: (event: WebSocketEventMap["close"]) => void;
   onError?: (event: WebSocketEventMap["error"]) => void;
+};
+
+type UsePartySocketOptions = PartySocketOptions & EventHandlerOptions;
+
+/** Updates options when any option changes that requires the socket to reconnect */
+const useStableOptions = (options: PartySocketOptions): PartySocketOptions => {
+  const identity = JSON.stringify([
+    options.id,
+    options.host,
+    options.party,
+    options.path,
+    options.protocol,
+    options.protocols,
+    // NOTE: if query is defined as a function, the code
+    // won't reconnect when you change the function identity
+    options.query,
+  ]);
+
+  return useMemo(() => {
+    return options;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [identity]);
 };
 
 // A React hook that wraps PartySocket
@@ -15,45 +37,89 @@ export default function usePartySocket(options: UsePartySocketOptions) {
   const { onOpen, onMessage, onClose, onError, ...partySocketOptions } =
     options;
 
-  const socketRef = useRef<PartySocket>(
-    new PartySocket({
-      ...partySocketOptions,
-      startClosed: true, // only connect on mount
-    })
+  const socketOptions = useStableOptions(partySocketOptions);
+  const socketRef = useRef<PartySocket | null>(null);
+  const [socket, setSocket] = useState<PartySocket>(
+    () =>
+      new PartySocket({
+        ...socketOptions,
+        // only connect on first mount
+        startClosed: true,
+      })
   );
+
+  const handlersRef = useRef<EventHandlerOptions>({});
+  handlersRef.current.onOpen = onOpen;
+  handlersRef.current.onMessage = onMessage;
+  handlersRef.current.onClose = onClose;
+  handlersRef.current.onError = onError;
 
   // note: this effect must be defined before the auto-connect effect below
   useEffect(() => {
-    const socket = socketRef.current;
-    if (onOpen) socket.addEventListener("open", onOpen);
-    if (onClose) socket.addEventListener("close", onClose);
-    if (onError) socket.addEventListener("error", onError);
-    if (onMessage) socket.addEventListener("message", onMessage);
+    const _onOpen: typeof onOpen = (event) =>
+      handlersRef.current?.onOpen?.(event);
+    const _onMessage: typeof onMessage = (event) =>
+      handlersRef.current?.onMessage?.(event);
+    const _onClose: typeof onClose = (event) =>
+      handlersRef.current?.onClose?.(event);
+    const _onError: typeof onError = (event) =>
+      handlersRef.current?.onError?.(event);
+
+    socket.addEventListener("open", _onOpen);
+    socket.addEventListener("close", _onClose);
+    socket.addEventListener("error", _onError);
+    socket.addEventListener("message", _onMessage);
 
     return () => {
-      if (onOpen) socket.removeEventListener("open", onOpen);
-      if (onClose) socket.removeEventListener("close", onClose);
-      if (onError) socket.removeEventListener("error", onError);
-      if (onMessage) socket.removeEventListener("message", onMessage);
+      socket.removeEventListener("open", _onOpen);
+      socket.removeEventListener("close", _onClose);
+      socket.removeEventListener("error", _onError);
+      socket.removeEventListener("message", _onMessage);
     };
-  }, [onOpen, onMessage, onClose, onError]);
+  }, [socket]);
 
-  // note: this effect must be defined after the event listener registration above
-  useEffect(
-    () => {
-      const socket = socketRef.current;
-      if (options.startClosed !== true) {
+  useEffect(() => {
+    console.log(
+      "Running hook",
+      socketRef.current === socket,
+      socketRef.current
+    );
+    // if new options have come in but we haven't yet reinitialized the socket
+    if (socketRef.current === socket) {
+      console.log("Creating new socket...", socketOptions);
+
+      // create new socket
+      const newSocket = new PartySocket({
+        ...socketOptions,
+        // when reconnecting because of options change, we always reconnect
+        // (startClosed only applies to initial mount)
+        startClosed: false,
+      });
+
+      // update socket reference (this will cause the effect to run again)
+      setSocket(newSocket);
+    } else {
+      console.log("Configuring existing socket...", socketOptions);
+
+      // if this is the first time we are running the hook, connect...
+      if (!socketRef.current && socketOptions.startClosed !== true) {
+        console.log("Initial connection...");
         socket.reconnect();
       }
 
+      // track initialized socket so we know not to do it again
+      // when options next change
+      socketRef.current = socket;
+
+      // close the old socket the next time the socket changes or we unmount
       return () => {
+        console.log("Closing socket");
         socket.close();
       };
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
-  return socketRef.current;
+    }
+  }, [socket, socketOptions]);
+
+  return socket;
 }
 
 export { useWebSocketImpl as useWebSocket };

--- a/packages/partysocket/src/react.ts
+++ b/packages/partysocket/src/react.ts
@@ -19,7 +19,7 @@ export default function usePartySocket(options: UsePartySocketOptions) {
     createSocket: (options) => new PartySocket(options),
     createSocketMemoKey: (options) =>
       JSON.stringify([
-        // NOTE: if query is defined as a function, the code
+        // NOTE: if query is defined as a function, the socket
         // won't reconnect when you change the function identity
         options.query,
         options.id,

--- a/packages/partysocket/src/react.ts
+++ b/packages/partysocket/src/react.ts
@@ -1,127 +1,43 @@
-import { useEffect, useRef, useMemo, useState } from "react";
 import type { PartySocketOptions } from ".";
 import PartySocket from ".";
-import useWebSocketImpl from "./use-ws";
 
-type EventHandlerOptions = {
-  onOpen?: (event: WebSocketEventMap["open"]) => void;
-  onMessage?: (event: WebSocketEventMap["message"]) => void;
-  onClose?: (event: WebSocketEventMap["close"]) => void;
-  onError?: (event: WebSocketEventMap["error"]) => void;
-};
+import {
+  getOptionsThatShouldCauseRestartWhenChanged,
+  useStableSocket,
+} from "./use-socket";
+import {
+  useAttachWebSocketEventHandlers,
+  type EventHandlerOptions,
+} from "./use-handlers";
 
 type UsePartySocketOptions = PartySocketOptions & EventHandlerOptions;
 
-/** Updates options when any option changes that requires the socket to reconnect */
-const useStableOptions = (options: PartySocketOptions): PartySocketOptions => {
-  const identity = JSON.stringify([
-    options.id,
-    options.host,
-    options.party,
-    options.path,
-    options.protocol,
-    options.protocols,
-    // NOTE: if query is defined as a function, the code
-    // won't reconnect when you change the function identity
-    options.query,
-  ]);
-
-  return useMemo(() => {
-    return options;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [identity]);
-};
-
 // A React hook that wraps PartySocket
 export default function usePartySocket(options: UsePartySocketOptions) {
-  const { onOpen, onMessage, onClose, onError, ...partySocketOptions } =
-    options;
+  const socket = useStableSocket({
+    options,
+    createSocket: (options) => new PartySocket(options),
+    createSocketMemoKey: (options) =>
+      JSON.stringify([
+        // NOTE: if query is defined as a function, the code
+        // won't reconnect when you change the function identity
+        options.query,
+        options.id,
+        options.host,
+        options.party,
+        options.path,
+        options.protocol,
+        options.protocols,
+        ...getOptionsThatShouldCauseRestartWhenChanged(options),
+      ]),
+  });
 
-  const socketOptions = useStableOptions(partySocketOptions);
-  const socketRef = useRef<PartySocket | null>(null);
-  const [socket, setSocket] = useState<PartySocket>(
-    () =>
-      new PartySocket({
-        ...socketOptions,
-        // only connect on first mount
-        startClosed: true,
-      })
-  );
-
-  const handlersRef = useRef<EventHandlerOptions>({});
-  handlersRef.current.onOpen = onOpen;
-  handlersRef.current.onMessage = onMessage;
-  handlersRef.current.onClose = onClose;
-  handlersRef.current.onError = onError;
-
-  // note: this effect must be defined before the auto-connect effect below
-  useEffect(() => {
-    const _onOpen: typeof onOpen = (event) =>
-      handlersRef.current?.onOpen?.(event);
-    const _onMessage: typeof onMessage = (event) =>
-      handlersRef.current?.onMessage?.(event);
-    const _onClose: typeof onClose = (event) =>
-      handlersRef.current?.onClose?.(event);
-    const _onError: typeof onError = (event) =>
-      handlersRef.current?.onError?.(event);
-
-    socket.addEventListener("open", _onOpen);
-    socket.addEventListener("close", _onClose);
-    socket.addEventListener("error", _onError);
-    socket.addEventListener("message", _onMessage);
-
-    return () => {
-      socket.removeEventListener("open", _onOpen);
-      socket.removeEventListener("close", _onClose);
-      socket.removeEventListener("error", _onError);
-      socket.removeEventListener("message", _onMessage);
-    };
-  }, [socket]);
-
-  useEffect(() => {
-    console.log(
-      "Running hook",
-      socketRef.current === socket,
-      socketRef.current
-    );
-    // if new options have come in but we haven't yet reinitialized the socket
-    if (socketRef.current === socket) {
-      console.log("Creating new socket...", socketOptions);
-
-      // create new socket
-      const newSocket = new PartySocket({
-        ...socketOptions,
-        // when reconnecting because of options change, we always reconnect
-        // (startClosed only applies to initial mount)
-        startClosed: false,
-      });
-
-      // update socket reference (this will cause the effect to run again)
-      setSocket(newSocket);
-    } else {
-      console.log("Configuring existing socket...", socketOptions);
-
-      // if this is the first time we are running the hook, connect...
-      if (!socketRef.current && socketOptions.startClosed !== true) {
-        console.log("Initial connection...");
-        socket.reconnect();
-      }
-
-      // track initialized socket so we know not to do it again
-      // when options next change
-      socketRef.current = socket;
-
-      // close the old socket the next time the socket changes or we unmount
-      return () => {
-        console.log("Closing socket");
-        socket.close();
-      };
-    }
-  }, [socket, socketOptions]);
+  useAttachWebSocketEventHandlers(socket, options);
 
   return socket;
 }
 
-export { useWebSocketImpl as useWebSocket };
+export { default as useWebSocket } from "./use-ws";
+
 // TODO: remove the default export in a future breaking change
 export { usePartySocket };

--- a/packages/partysocket/src/use-handlers.ts
+++ b/packages/partysocket/src/use-handlers.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+import type WebSocket from "./ws";
+
+export type EventHandlerOptions = {
+  onOpen?: (event: WebSocketEventMap["open"]) => void;
+  onMessage?: (event: WebSocketEventMap["message"]) => void;
+  onClose?: (event: WebSocketEventMap["close"]) => void;
+  onError?: (event: WebSocketEventMap["error"]) => void;
+};
+
+/** Attaches event handlers to a WebSocket in a React Lifecycle-friendly way */
+export const useAttachWebSocketEventHandlers = (
+  socket: WebSocket,
+  options: EventHandlerOptions
+) => {
+  const handlersRef = useRef(options);
+  handlersRef.current = options;
+
+  useEffect(() => {
+    const onOpen: EventHandlerOptions["onOpen"] = (event) =>
+      handlersRef.current?.onOpen?.(event);
+    const onMessage: EventHandlerOptions["onMessage"] = (event) =>
+      handlersRef.current?.onMessage?.(event);
+    const onClose: EventHandlerOptions["onClose"] = (event) =>
+      handlersRef.current?.onClose?.(event);
+    const onError: EventHandlerOptions["onError"] = (event) =>
+      handlersRef.current?.onError?.(event);
+
+    socket.addEventListener("open", onOpen);
+    socket.addEventListener("close", onClose);
+    socket.addEventListener("error", onError);
+    socket.addEventListener("message", onMessage);
+
+    return () => {
+      socket.removeEventListener("open", onOpen);
+      socket.removeEventListener("close", onClose);
+      socket.removeEventListener("error", onError);
+      socket.removeEventListener("message", onMessage);
+    };
+  }, [socket]);
+};

--- a/packages/partysocket/src/use-socket.ts
+++ b/packages/partysocket/src/use-socket.ts
@@ -1,0 +1,82 @@
+import type WebSocket from "./ws";
+import type { Options } from "./ws";
+import { useRef, useMemo, useState, useEffect } from "react";
+
+/** When any of the option values are changed, we should reinitialize the socket */
+export const getOptionsThatShouldCauseRestartWhenChanged = (
+  options: Options
+) => [
+  options.startClosed,
+  options.minUptime,
+  options.maxRetries,
+  options.connectionTimeout,
+  options.maxEnqueuedMessages,
+  options.maxReconnectionDelay,
+  options.minReconnectionDelay,
+  options.reconnectionDelayGrowFactor,
+  options.debug,
+];
+
+/**
+ * Initializes a PartySocket (or WebSocket) and keeps it stable across renders,
+ * but reconnects and updates the reference when any of the connection args change.
+ */
+export function useStableSocket<T extends WebSocket, TOpts extends Options>({
+  options,
+  createSocket,
+  createSocketMemoKey: createOptionsMemoKey,
+}: {
+  options: TOpts;
+  createSocket: (options: TOpts) => T;
+  createSocketMemoKey: (options: TOpts) => string;
+}) {
+  // ensure we only reconnect when necessary
+  const shouldReconnect = createOptionsMemoKey(options);
+  const socketOptions = useMemo(() => {
+    return options;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldReconnect]);
+
+  // this is the socket we return
+  const [socket, setSocket] = useState<T>(() =>
+    // only connect on first mount
+    createSocket({ ...socketOptions, startClosed: true })
+  );
+
+  // keep track of the socket we initialized
+  const socketInitializedRef = useRef<T | null>(null);
+
+  // allow changing the socket factory without reconnecting
+  const createSocketRef = useRef(createSocket);
+  createSocketRef.current = createSocket;
+
+  // finally, initialize the socket
+  useEffect(() => {
+    // we haven't yet restarted the socket
+    if (socketInitializedRef.current === socket) {
+      // create new socket
+      const newSocket = createSocketRef.current({
+        ...socketOptions,
+        // when reconnecting because of options change, we always reconnect
+        // (startClosed only applies to initial mount)
+        startClosed: false,
+      });
+
+      // update socket reference (this will cause the effect to run again)
+      setSocket(newSocket);
+    } else {
+      // if this is the first time we are running the hook, connect...
+      if (!socketInitializedRef.current && socketOptions.startClosed !== true) {
+        socket.reconnect();
+      }
+      // track initialized socket so we know not to do it again
+      socketInitializedRef.current = socket;
+      // close the old socket the next time the socket changes or we unmount
+      return () => {
+        socket.close();
+      };
+    }
+  }, [socket, socketOptions]);
+
+  return socket;
+}


### PR DESCRIPTION
This PR fixes multiple issues in `usePartySocket` and `useWebSocket`:

- When props such as url, host, party etc were set dynamically, the socket would not reconnect and would remain connected with the existing parameters
- When event handlers were provided as functions, the socket would reconnect when function references changed

This change (seemingly) introduces some additional complexity to the code. In order to avoid duplication of said complexity between `usePartySocket` and `useWebSocket` I introduced some additional indirection, but I think that's worth it in this case.

Ideally we should have automated tests for this, but testing react hook lifecycles is a little tricky and we don't have infra set up for it, so in lieu I extensively tested this manually in different scenarios (strict mode, non-strict, etc) and it seems to work as expected.