### PR TITLE
Fix stub.fetch types to allow forwarding Request directly

### DIFF
--- a/.changeset/sharp-schools-relate.md
+++ b/.changeset/sharp-schools-relate.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Allow passing request directly to stub.fetch

--- a/examples/class/src/server.ts
+++ b/examples/class/src/server.ts
@@ -7,7 +7,12 @@ type Connection = Party.Connection<{ country: string | undefined }>;
 export default class Main implements Party.Server {
   // onBefore* handlers that run in the worker nearest the user are now
   // explicitly marked static, because they have no access to Party state
-  static async onBeforeRequest(req: Party.Request) {
+  static async onBeforeRequest(req: Party.Request, lobby: Party.Lobby) {
+    await lobby.parties.main.get(lobby.id).fetch("/foo");
+    await lobby.parties.main.get(lobby.id).fetch(req);
+
+    await lobby.parties.main.get(lobby.id).fetch(req.url, req);
+
     return req;
   }
   static async onBeforeConnect(req: Party.Request) {

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -89,17 +89,17 @@ function createMultiParties(
     for (const [key, value] of Object.entries(namespaces)) {
       if (typeof value.idFromName === "function") {
         parties[key] ||= {
-          get: (name: string) => {
+          get: (name: string): Party.Stub => {
             const docId = value.idFromName(name).toString();
             const id = value.idFromString(docId);
             const stub = value.get(id);
             return {
               fetch(
-                pathOrInit?: string | RequestInit,
-                maybeInit?: RequestInit
+                pathOrInit?: string | RequestInit | Request,
+                maybeInit?: RequestInit | Request
               ) {
                 let path: RequestInfo | undefined;
-                let init: RequestInit | undefined;
+                let init: RequestInit | Request | undefined;
                 if (pathOrInit) {
                   if (typeof pathOrInit === "string") {
                     path = pathOrInit;

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -47,14 +47,10 @@ export type ConnectionContext = { request: CFRequest };
 export type Stub = {
   /** @deprecated Use `await socket()` instead */
   connect: () => WebSocket;
-  socket: (
-    pathOrInit?: string | RequestInit,
-    maybeInit?: RequestInit
-  ) => Promise<WebSocket>;
-  fetch: (
-    pathOrInit?: string | RequestInit,
-    maybeInit?: RequestInit
-  ) => Promise<Response>;
+  socket(pathOrInit: string | RequestInit): Promise<WebSocket>;
+  socket(path: string, init: RequestInit): Promise<WebSocket>;
+  fetch(pathOrInit: string | RequestInit | ReturnRequest): Promise<Response>;
+  fetch(path: string, init: RequestInit | ReturnRequest): Promise<Response>;
 };
 
 /** Additional information about other resources in the current project */

--- a/packages/partykit/src/server.ts
+++ b/packages/partykit/src/server.ts
@@ -47,10 +47,10 @@ export type ConnectionContext = { request: CFRequest };
 export type Stub = {
   /** @deprecated Use `await socket()` instead */
   connect: () => WebSocket;
-  socket(pathOrInit: string | RequestInit): Promise<WebSocket>;
-  socket(path: string, init: RequestInit): Promise<WebSocket>;
-  fetch(pathOrInit: string | RequestInit | ReturnRequest): Promise<Response>;
-  fetch(path: string, init: RequestInit | ReturnRequest): Promise<Response>;
+  socket(pathOrInit?: string | RequestInit): Promise<WebSocket>;
+  socket(path: string, init?: RequestInit): Promise<WebSocket>;
+  fetch(pathOrInit?: string | RequestInit | ReturnRequest): Promise<Response>;
+  fetch(path: string, init?: RequestInit | ReturnRequest): Promise<Response>;
 };
 
 /** Additional information about other resources in the current project */


### PR DESCRIPTION
Makes it possible to route requests without type hackery, as in https://github.com/partykit/example-sharding/blob/main/src/router.ts#L22

```diff
    return lobby.parties.main
      .get(id)
-     .fetch(req as unknown as RequestInit);
+     .fetch(req);
```