### PR TITLE
validating project name in config

### DIFF
--- a/.changeset/warm-tables-jump.md
+++ b/.changeset/warm-tables-jump.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+validating project name in config

--- a/packages/partykit/src/config.ts
+++ b/packages/partykit/src/config.ts
@@ -386,6 +386,13 @@ export function getConfig(
     console.warn('Configuration field "account" is not yet operational');
   }
 
+  if (config.name) {
+    const validPathRegex = new RegExp("^[a-zA-Z0-9-]+$")
+    if (!validPathRegex.test(config.name)) {
+      throw new ConfigurationError("Project name must be a valid url path")
+    }
+  }
+
   if (config.main) {
     if (overrides.main) {
       const absoluteMainPath = path.isAbsolute(overrides.main)


### PR DESCRIPTION
I had an issue with my project name previously, I had an underscore in the name of the project, and since the project name is included in the url for the party, I had two separate issues:

1. i could not deploy initially, there was a problem with uploading my files that was caused by the path name
2. i had a ERR_SSL_VERSION_OR_CIPHER_MISMATCH error in the client when trying to connect via partysocket

this second error I think was caused by subdomain issue in cloudflare https://developers.cloudflare.com/ssl/troubleshooting/version-cipher-mismatch/

this pr just adds a simple check to the config file to make sure that the name of the project will work as a url path segment