### PR TITLE
adding room validation to partysocket

### DIFF
--- a/.changeset/selfish-kids-guess.md
+++ b/.changeset/selfish-kids-guess.md
@@ -1,0 +1,5 @@
+---
+"partysocket": patch
+---
+
+adding room validation to partysocket

--- a/packages/partysocket/src/index.ts
+++ b/packages/partysocket/src/index.ts
@@ -80,19 +80,24 @@ function getPartyInfo(
   if (rawPath && rawPath.startsWith("/")) {
     throw new Error("path must not start with a slash");
   }
+  if (room) {
+    const validPathRegex = new RegExp("^[a-zA-Z0-9-]+$")
+    if (!validPathRegex.test(room)) {
+      throw new Error("room name must be a valid path segment")
+    }
+  }
   const name = party ?? "main";
   const path = rawPath ? `/${rawPath}` : "";
   const protocol =
     rawProtocol ||
     (host.startsWith("localhost:") || host.startsWith("127.0.0.1:")
       ? // http / ws
-        defaultProtocol
+      defaultProtocol
       : // https / wss
-        defaultProtocol + "s");
+      defaultProtocol + "s");
 
-  const baseUrl = `${protocol}://${host}/${
-    party ? `parties/${party}` : "party"
-  }/${room}${path}`;
+  const baseUrl = `${protocol}://${host}/${party ? `parties/${party}` : "party"
+    }/${room}${path}`;
 
   const makeUrl = (query: Params = {}) =>
     `${baseUrl}?${new URLSearchParams([


### PR DESCRIPTION
this adds another very simple check that the room name in the partysocket config is a valid path segment, there might be more options for room names depending on how you guys are implementing things on the back end, but at least now there is a central place to do the validation. Hoping this (at least partially) covers what is meant in issues #298  and #117 

this doesn't address connecting to parties from within a party server, but if pr #395 gets implemented, that issue will be solved

this was a little bit of guess work as to what the goals were here but I hope it helps!