### PR TITLE
partysocket: fix node usage

### DIFF
--- a/.changeset/thirty-taxis-provide.md
+++ b/.changeset/thirty-taxis-provide.md
@@ -1,0 +1,7 @@
+---
+"partysocket": patch
+---
+
+partysocket: fix node usage
+
+When cloning websocket events in node, it looks like it misses the `data` field for messages. This patch adds it on to the cloned event.

--- a/examples/test-node/package.json
+++ b/examples/test-node/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@partykit/examples-test-node",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "start": "partykit dev"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "ws": "^8.14.2"
+  }
+}

--- a/examples/test-node/partykit.json
+++ b/examples/test-node/partykit.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-node",
+  "main": "src/server.ts",
+  "compatibilityDate": "2023-09-28"
+}

--- a/examples/test-node/script.mjs
+++ b/examples/test-node/script.mjs
@@ -1,0 +1,34 @@
+/* eslint-disable no-undef */
+import WS from "ws";
+import PartySocket from "partysocket";
+
+const ps = new PartySocket({
+  host: "127.0.0.1:1999",
+  room: "test",
+  WebSocket: WS,
+});
+
+ps.addEventListener("open", () => {
+  console.log("connected");
+  ps.send("hello");
+});
+
+ps.addEventListener("message", (e) => {
+  console.log("message", e, e.data);
+});
+
+ps.onmessage = (e) => {
+  console.log("message", e, e.data);
+};
+
+ps.addEventListener("close", () => {
+  console.log("closed");
+});
+
+ps.addEventListener("error", (e) => {
+  console.log("error", e);
+});
+
+ps.reconnect();
+
+console.log("connecting...");

--- a/examples/test-node/src/client.ts
+++ b/examples/test-node/src/client.ts
@@ -1,0 +1,46 @@
+import PartySocket from "partysocket";
+
+declare const PARTYKIT_HOST: string;
+
+document.getElementById("app")!.innerText = location.href;
+
+const partySocket = new PartySocket({
+  host: PARTYKIT_HOST,
+  room: "some-room",
+});
+
+const latencyPingStarts = new Map();
+
+partySocket.onerror = (err) => console.error({ err });
+partySocket.onclose = (evt) => console.log("closed", evt);
+partySocket.onopen = () => partySocket.send("ping");
+partySocket.onmessage = (evt) => {
+  const data = evt.data as string;
+  if (data.startsWith("latency:")) {
+    const id = data.split(":")[1];
+    const latency = Date.now() - latencyPingStarts.get(id);
+    latencyPingStarts.delete(id);
+    latencyMonitor.innerText = `${latency / 2}ms`;
+  }
+};
+
+setInterval(() => {
+  const id = crypto.randomUUID();
+  latencyPingStarts.set(id, Date.now());
+  partySocket.send(`latency:${id}`);
+}, 1000);
+
+const latencyMonitor = document.createElement("div");
+Object.assign(latencyMonitor.style, {
+  position: "fixed",
+  top: "0",
+  right: "0",
+  width: "100px",
+  height: "100px",
+  "text-align": "center",
+  background: "white",
+  padding: "10px",
+  zIndex: "9999",
+});
+
+document.body.appendChild(latencyMonitor);

--- a/examples/test-node/src/server.ts
+++ b/examples/test-node/src/server.ts
@@ -1,0 +1,31 @@
+import type * as Party from "partykit/server";
+
+export default class Server implements Party.Server {
+  constructor(readonly party: Party.Party) {}
+
+  onConnect(conn: Party.Connection, ctx: Party.ConnectionContext) {
+    // A websocket just connected!
+    console.log(
+      `Connected:
+  id: ${conn.id}
+  room: ${this.party.id}
+  url: ${new URL(ctx.request.url).pathname}`
+    );
+
+    // let's send a message to the connection
+    conn.send("hello from server");
+  }
+
+  onMessage(message: string, sender: Party.Connection) {
+    // let's log the message
+    console.log(`connection ${sender.id} sent message: ${message}`);
+    // as well as broadcast it to all the other connections in the room...
+    this.party.broadcast(
+      `${sender.id}: ${message}`,
+      // ...except for the connection it came from
+      [sender.id]
+    );
+  }
+}
+
+Server satisfies Party.Worker;

--- a/examples/test-node/src/xyz.ts
+++ b/examples/test-node/src/xyz.ts
@@ -1,0 +1,15 @@
+import type { PartyKitServer } from "partykit/server";
+
+export default {
+  // onBeforeRequest(_req) {
+  //   console.log("xyz before request");
+  //   return new Response("Hello from xyz request");
+  // },
+  onRequest(_req) {
+    return new Response("Hello from xyz");
+  },
+  onConnect(ws, _room) {
+    console.log("xyz connected");
+    ws.send("ping from xyz");
+  },
+} satisfies PartyKitServer;

--- a/examples/test-node/tsconfig.json
+++ b/examples/test-node/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.base.json"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1136,6 +1136,14 @@
         "typescript": "^5.2.2"
       }
     },
+    "examples/test-node": {
+      "name": "@partykit/examples-test-node",
+      "version": "0.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "ws": "^8.14.2"
+      }
+    },
     "examples/wasm": {
       "name": "@partykit/examples-wasm",
       "version": "0.0.0",
@@ -5650,6 +5658,10 @@
     },
     "node_modules/@partykit/examples-socket.io": {
       "resolved": "examples/socket.io-chat",
+      "link": true
+    },
+    "node_modules/@partykit/examples-test-node": {
+      "resolved": "examples/test-node",
       "link": true
     },
     "node_modules/@partykit/examples-wasm": {

--- a/packages/partysocket/src/ws.ts
+++ b/packages/partysocket/src/ws.ts
@@ -76,7 +76,10 @@ function cloneEventBrowser(e: Event) {
 }
 
 function cloneEventNode(e: Event) {
-  return new Event(e.type, e);
+  const evt = new Event(e.type, e);
+  // @ts-expect-error we need to fix event/listener types
+  evt.data = e.data;
+  return evt;
 }
 
 const isNode =


### PR DESCRIPTION
When cloning websocket events in node, it looks like it misses the `data` field for messages. This patch adds it on to the cloned event.