### PR TITLE
Gets homepage cursors working

### DIFF
--- a/apps/site/party/presence.ts
+++ b/apps/site/party/presence.ts
@@ -30,7 +30,7 @@ const CORS = {
 export default class PresenceServer implements Party.Server {
   constructor(public party: Party.Party) {}
   options: Party.ServerOptions = {
-    hibernate: true,
+    hibernate: false,
   };
 
   // pending updates are stored in memory and sent every tick
@@ -47,10 +47,13 @@ export default class PresenceServer implements Party.Server {
   ): void | Promise<void> {
     const metadata = { country: request.cf?.country ?? null } as Metadata;
 
-    // Stash the metdata on the websocket
-    connection.setState({ metadata });
+    // Stash the metadata on the websocket
+    connection.setState((prevState: User) => ({ ...prevState, metadata }));
 
-    //console.log("onConnect", this.party.id, connection.id, country);
+    const sync = this.makeSyncMessage();
+    connection.send(encodePartyMessage(sync));
+
+    //console.log("onConnect", this.party.id, connection.id, request.cf?.country);
   }
 
   enqueueAdd(id: string, user: User) {
@@ -71,6 +74,20 @@ export default class PresenceServer implements Party.Server {
       presence: connection.state?.presence ?? ({} as Presence),
       metadata: connection.state?.metadata ?? ({} as Metadata),
     };
+  }
+
+  makeSyncMessage() {
+    // Build users list
+    let users = <Record<string, User>>{};
+    for (const connection of this.party.getConnections()) {
+      const user = this.getUser(connection);
+      users[connection.id] = user;
+    }
+
+    return {
+      type: "sync",
+      users,
+    } satisfies PartyMessage;
   }
 
   onMessage(
@@ -96,28 +113,19 @@ export default class PresenceServer implements Party.Server {
         }));
         this.enqueueAdd(connection.id, this.getUser(connection));
         // Reply with the current presence of all connections, including self
-        const sync = {
-          type: "sync",
-          users: [...this.party.getConnections()].reduce(
-            (acc, user) => ({ ...acc, [user.id]: this.getUser(user) }),
-            {},
-          ),
-        } satisfies PartyMessage;
+        const sync = this.makeSyncMessage();
         //connection.send(JSON.stringify(sync));
+        //console.log("sync", JSON.stringify(sync, null, 2));
         connection.send(encodePartyMessage(sync));
         break;
       }
       case "update": {
-        // A presence update
+        // A presence update, replacing the existing presence
         connection.setState((prevState) => {
-          const presence = {
-            ...(prevState?.presence ?? ({} as Presence)),
-            ...message.presence,
-          };
-          this.enqueuePresence(connection.id, presence);
+          this.enqueuePresence(connection.id, message.presence);
           return {
             ...prevState,
-            presence,
+            presence: message.presence,
           };
         });
         break;

--- a/apps/site/party/presence.ts
+++ b/apps/site/party/presence.ts
@@ -78,7 +78,7 @@ export default class PresenceServer implements Party.Server {
 
   makeSyncMessage() {
     // Build users list
-    let users = <Record<string, User>>{};
+    const users = <Record<string, User>>{};
     for (const connection of this.party.getConnections()) {
       const user = this.getUser(connection);
       users[connection.id] = user;

--- a/apps/site/src/interactive/RoomContainer.jsx
+++ b/apps/site/src/interactive/RoomContainer.jsx
@@ -5,6 +5,7 @@ export default function RoomContainer() {
   return (
   <PresenceProvider
   host="partykit-site.genmon.partykit.dev"
+  //host="127.0.0.1:1999"
   room="default"
   presence={{
     cursor: null,

--- a/apps/site/src/interactive/RoomContainer.jsx
+++ b/apps/site/src/interactive/RoomContainer.jsx
@@ -6,7 +6,7 @@ export default function RoomContainer() {
   <PresenceProvider
   host="partykit-site.genmon.partykit.dev"
   //host="127.0.0.1:1999"
-  room="default"
+  room="default-20231128"
   presence={{
     cursor: null,
     message: null,

--- a/apps/site/src/interactive/presence/presence-context.tsx
+++ b/apps/site/src/interactive/presence/presence-context.tsx
@@ -35,7 +35,7 @@ type PresenceStoreType = {
 
   // A local update to the presence of the current user,
   // ready to the sent to the server as an "update" ClientMessage
-  pendingUpdate: Partial<Presence> | null;
+  pendingUpdate: Presence | null;
   clearPendingUpdate: () => void;
 
   // Makes an optimistic local update of the presence of the current user,
@@ -78,7 +78,7 @@ export const usePresence = create<PresenceStoreType>((set) => ({
         ...state.myself,
         presence,
       };
-      return { myself, pendingUpdate: partial };
+      return { myself, pendingUpdate: presence };
     }),
 
   otherUsers: new Map() as UserMap,

--- a/apps/site/src/interactive/presence/presence-schema.ts
+++ b/apps/site/src/interactive/presence/presence-schema.ts
@@ -108,9 +108,11 @@ export function decodeMessage(message: string | ArrayBufferLike) {
 
 // creates a msgpack message
 export function encodePartyMessage(data: z.infer<typeof partyMessageSchema>) {
-  return encode(partyMessageSchema.parse(data));
+  //return encode(partyMessageSchema.parse(data));
+  return encode(data);
 }
 
 export function encodeClientMessage(data: z.infer<typeof clientMessageSchema>) {
-  return encode(clientMessageSchema.parse(data));
+  //return encode(clientMessageSchema.parse(data));
+  return encode(data);
 }

--- a/apps/site/src/interactive/presence/presence-schema.ts
+++ b/apps/site/src/interactive/presence/presence-schema.ts
@@ -48,7 +48,7 @@ export type ClientMessage =
     }
   | {
       type: "update";
-      presence: Partial<Presence>;
+      presence: Presence;
     };
 
 // Schema created with https://transform.tools/typescript-to-zod
@@ -96,7 +96,7 @@ export const clientMessageSchema = z.union([
   }),
   z.object({
     type: z.literal("update"),
-    presence: presenceSchema.partial(),
+    presence: presenceSchema,
   }),
 ]);
 


### PR DESCRIPTION
- Removes Zod checks
- Removes partial presence updates from the client
- Doesn't send out empty presences in the sync message
- Changes the default room name

To do: fix assumptions around the "join" message