### PR TITLE
Linting and display nits

### DIFF
--- a/apps/site/party/presence.ts
+++ b/apps/site/party/presence.ts
@@ -153,11 +153,11 @@ export default class PresenceServer implements Party.Server {
     });
   }
 
-  onClose(connection: ConnectionWithUser): void | Promise<void> {
+  onClose(connection: ConnectionWithUser) {
     this.leave(connection);
   }
 
-  onError(connection: ConnectionWithUser, err: Error): void | Promise<void> {
+  onError(connection: ConnectionWithUser) {
     this.leave(connection);
   }
 

--- a/apps/site/src/components/content/Hero.astro
+++ b/apps/site/src/components/content/Hero.astro
@@ -1,7 +1,6 @@
 ---
 import "../../styles/variables.scss";
 import Scene from "../../interactive/Scene";
-import Voronoi from "../../interactive/Voronoi";
 ---
 
 <div id="hero">

--- a/apps/site/src/components/content/Terminal.astro
+++ b/apps/site/src/components/content/Terminal.astro
@@ -1,7 +1,6 @@
 ---
 import { Code } from "astro:components";
 import "../../styles/variables.scss";
-import Button from "../atoms/Button.astro";
 ---
 
 <div id="terminal">

--- a/apps/site/src/components/sections/Company.astro
+++ b/apps/site/src/components/sections/Company.astro
@@ -2,7 +2,6 @@
 import BlogPost from "../cards/BlogPost.astro";
 import Button from "../atoms/Button.astro";
 import Grid from "../Grid.astro";
-import SectionNav from "../SectionNav.astro";
 import blogposts from "../../blog.json";
 ---
 

--- a/apps/site/src/components/sections/Introduction.astro
+++ b/apps/site/src/components/sections/Introduction.astro
@@ -5,8 +5,6 @@ import MadeWith from "../cards/MadeWith.astro";
 import Button from "../atoms/Button.astro";
 import Compatibility from "../content/Compatibility.astro";
 import Grid from "../Grid.astro";
-import Limiter from "../Limiter.astro";
-import SectionNav from "../SectionNav.astro";
 ---
 
 <Grid>

--- a/apps/site/src/components/sections/Product.astro
+++ b/apps/site/src/components/sections/Product.astro
@@ -1,8 +1,5 @@
 ---
-import Button from "../atoms/Button.astro";
 import Quote from "../cards/Quote.astro";
-import Limiter from "../Limiter.astro";
-import SectionNav from "../SectionNav.astro";
 import Pricing from "../content/Pricing.astro";
 import Features from "../content/Features.astro";
 import Grid from "../Grid.astro";

--- a/apps/site/src/interactive/Voronoi.tsx
+++ b/apps/site/src/interactive/Voronoi.tsx
@@ -153,8 +153,9 @@ export default function Voronoi() {
 
   const count = usePresenceWithCursors(
     (state) =>
-      [...state.otherUsers.keys()].length +
-      (state.myself?.presence?.cursor ? 1 : 0),
+      Array.from(state.otherUsers.values()).filter(
+        (user) => user.presence?.cursor,
+      ).length + (state.myself?.presence?.cursor ? 1 : 0),
   );
 
   useEffect(() => {

--- a/apps/site/src/interactive/presence/other-cursors.tsx
+++ b/apps/site/src/interactive/presence/other-cursors.tsx
@@ -10,7 +10,8 @@ export default function OtherCursors() {
     <div
       className={`${
         within === "window" ? "fixed" : "absolute"
-      } z-20 top-0 left-0 right-0 bottom-0 pointer-events-none overflow-clip`}
+      } top-0 left-0 right-0 bottom-0 pointer-events-none overflow-clip`}
+      style={{ zIndex: 1001 }}
     >
       {otherUserIds.map((id) => {
         return <Cursor key={id} userId={id} fill={"#00f"} />;

--- a/apps/site/src/layouts/Document.astro
+++ b/apps/site/src/layouts/Document.astro
@@ -3,7 +3,6 @@ import Layout from "./Layout.astro";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import Grid from "../components/Grid.astro";
-import Button from "../components/atoms/Button.astro";
 
 interface Props {
   title: string;


### PR DESCRIPTION
- Fixes some Astro linting
- Updates the display count on the homepage to count only the connections with visible cursors (i.e. doesn't count smartphone users who are not touching)
- Puts the cursors on top the sticky header, otherwise they hide and make the display count look inaccurate