### PR TITLE
feat: config.build.alias  / config.serve.build.alias

### DIFF
--- a/.changeset/unlucky-bottles-exercise.md
+++ b/.changeset/unlucky-bottles-exercise.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+feat: config.build.alias / config.serve.build.alias
+
+This lets you specify aliases for modules, just like esbuild's aliases.

--- a/packages/partykit/schema.json
+++ b/packages/partykit/schema.json
@@ -71,6 +71,12 @@
                     "minify": {
                       "type": "boolean"
                     },
+                    "alias": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
                     "format": {
                       "type": "string",
                       "enum": [
@@ -175,6 +181,12 @@
         },
         "watch": {
           "type": "string"
+        },
+        "alias": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -465,6 +465,7 @@ export async function deploy(options: {
     format: assetsBuild?.format ?? "esm",
     sourcemap: assetsBuild?.sourcemap ?? true,
     external: assetsBuild?.external,
+    alias: assetsBuild?.alias,
     define: {
       PARTYKIT_HOST: `"${config.name}.${
         config.team || user.login
@@ -614,6 +615,7 @@ export const ${name} = ${name}Party;
         ...esbuildOptions.define,
         ...config.define,
       },
+      alias: config.build?.alias,
       plugins: [
         nodejsCompatPlugin,
         {

--- a/packages/partykit/src/config-schema.ts
+++ b/packages/partykit/src/config-schema.ts
@@ -45,6 +45,7 @@ export const schema = z
                 external: z.array(z.string()).optional(),
                 outdir: z.string().optional(),
                 minify: z.boolean().optional(),
+                alias: z.record(z.string()).optional(),
                 format: z.enum(["esm", "cjs", "iife"]).optional(),
                 sourcemap: z.boolean().optional(),
                 define: z.record(z.string()).optional(),
@@ -69,6 +70,7 @@ export const schema = z
         command: z.string().optional(),
         cwd: z.string().optional(),
         watch: z.string().optional(),
+        alias: z.record(z.string()).optional(),
       })
       .strict()
       .optional(),

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -353,6 +353,7 @@ function useAssetServer(
         ...assetsBuild?.define,
       },
       loader: assetsBuild?.loader,
+      alias: assetsBuild?.alias,
     }),
     [assetsBuild, assetsPath, defines]
   );
@@ -582,6 +583,7 @@ Workers["${name}"] = ${name};
           ...esbuildOptions.define,
           ...config.define,
         },
+        alias: config.build?.alias,
         plugins: [
           nodejsCompatPlugin,
           {


### PR DESCRIPTION
This lets you specify aliases for modules, just like esbuild's aliases.