### PR TITLE
Inject every var as it's own var instead of a big PARTYKIT_VARS object

### DIFF
--- a/.changeset/empty-dogs-share.md
+++ b/.changeset/empty-dogs-share.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+Inject every var as it's own var instead of a big PARTYKIT_VARS object
+
+env vars have a 5kb limit, and people are hitting it. This should ease that off, without changing how we persist it ourselves.

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -73,12 +73,21 @@ type DurableObjectNamespaceEnv = {
 
 type Env = DurableObjectNamespaceEnv & {
   PARTYKIT_AI: Party.Party["ai"];
-  PARTYKIT_VARS: Record<string, unknown>;
   PARTYKIT_DURABLE: DurableObjectNamespace;
   PARTYKIT_VECTORIZE: Record<string, VectorizeClientOptions>;
 };
 
 let parties: Party.Party["context"]["parties"];
+
+function extractVars(obj: Record<string, unknown>): Record<string, unknown> {
+  const vars: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (key.startsWith("pkvar-")) {
+      vars[key.slice(`pkvar-`.length)] = value;
+    }
+  }
+  return vars;
+}
 
 // create a "multi-party" object that can be used to connect to other parties
 function createMultiParties(
@@ -260,7 +269,6 @@ function createDurable(
       super();
 
       const {
-        PARTYKIT_VARS,
         PARTYKIT_AI,
         PARTYKIT_DURABLE,
         PARTYKIT_VECTORIZE,
@@ -303,7 +311,7 @@ function createDurable(
         },
         internalID: this.controller.id.toString(),
         name: options.name,
-        env: PARTYKIT_VARS,
+        env: extractVars(env),
         ai: PARTYKIT_AI,
         storage: this.controller.storage,
         blockConcurrencyWhile: this.controller.blockConcurrencyWhile.bind(
@@ -644,7 +652,6 @@ export default {
       // TODO: throw if room is longer than x characters
 
       const {
-        PARTYKIT_VARS,
         PARTYKIT_AI,
         PARTYKIT_DURABLE,
         PARTYKIT_VECTORIZE,
@@ -714,7 +721,7 @@ export default {
                   mutableRequest,
                   {
                     id: roomId,
-                    env: PARTYKIT_VARS,
+                    env: extractVars(env),
                     ai: PARTYKIT_AI,
                     parties,
                     vectorize: vectorizeBindings,
@@ -758,7 +765,7 @@ export default {
                   mutableRequest,
                   {
                     id: roomId,
-                    env: PARTYKIT_VARS,
+                    env: extractVars(env),
                     ai: PARTYKIT_AI,
                     parties,
                     vectorize: vectorizeBindings,
@@ -807,7 +814,7 @@ export default {
           return await onFetch(
             request,
             {
-              env: PARTYKIT_VARS,
+              env: extractVars(env),
               ai: PARTYKIT_AI,
               parties,
               vectorize: vectorizeBindings,

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -663,6 +663,15 @@ function useDev(options: DevProps): {
         };
       }
     }
+
+    // prefix all vars with pkvar-
+    const vars = Object.entries(config.vars || {}).reduce<
+      Record<string, unknown>
+    >((obj, [key, value]) => {
+      obj[`pkvar-${key}`] = value;
+      return obj;
+    }, {});
+
     if (!config.compatibilityDate) {
       logger.warn(
         `No compatibilityDate specified in configuration, defaulting to ${currentUTCDate}
@@ -823,9 +832,7 @@ Workers["${name}"] = ${name};
                       ],
                       port: portForServer,
                       bindings: {
-                        ...(config.vars
-                          ? { PARTYKIT_VARS: config.vars as Json }
-                          : {}),
+                        ...vars,
                         ...(config.ai
                           ? {
                               PARTYKIT_AI:


### PR DESCRIPTION
env vars have a 5kb limit, and people are hitting it. This should ease that off, without changing how we persist it ourselves.