### PR TITLE
y-partykit remove ChunkedWebSocket class

### DIFF
--- a/.changeset/lovely-goats-divide.md
+++ b/.changeset/lovely-goats-divide.md
@@ -1,0 +1,7 @@
+---
+"y-partykit": patch
+---
+
+y-partykit remove ChunkedWebSocket class
+
+The class definition was eagerly looking for a WebSocket class, breaking in non-standards based environments (like node.js), leading to issues like https://github.com/partykit/partykit/issues/698. This removes the class definition, and uses the chunking function directly when required. I think this should fix the problem.

--- a/packages/y-partykit/src/chunking.ts
+++ b/packages/y-partykit/src/chunking.ts
@@ -27,12 +27,9 @@ type Batch = {
  * 3. The sender sends each chunk as a individual packet
  * 4. The sender sends a chunk end marker
  */
-export const sendChunked = (
-  data: ArrayBufferLike,
-  send: (data: ArrayBufferLike | string) => void
-) => {
+export const sendChunked = (data: ArrayBufferLike, ws: WebSocket) => {
   if (data.byteLength <= CHUNK_MAX_SIZE) {
-    send(data);
+    ws.send(data);
     return;
   }
 
@@ -48,7 +45,7 @@ export const sendChunked = (
   const id = (Date.now() + Math.random()).toString(36).substring(10);
   const chunks = Math.ceil(data.byteLength / CHUNK_MAX_SIZE);
 
-  send(
+  ws.send(
     serializeBatchMarker({
       id,
       type: "start",
@@ -61,12 +58,12 @@ export const sendChunked = (
   let sentChunks = 0;
   for (let i = 0; i < chunks; i++) {
     const chunk = data.slice(CHUNK_MAX_SIZE * i, CHUNK_MAX_SIZE * (i + 1));
-    send(chunk);
+    ws.send(chunk);
     sentChunks += 1;
     sentSize += chunk.byteLength;
   }
 
-  send(
+  ws.send(
     serializeBatchMarker({
       id,
       type: "end",

--- a/packages/y-partykit/src/index.ts
+++ b/packages/y-partykit/src/index.ts
@@ -7,7 +7,7 @@ import * as decoding from "lib0/decoding";
 import debounce from "lodash.debounce";
 import type * as Party from "partykit/server";
 import { YPartyKitStorage } from "./storage";
-import { handleChunked } from "./chunking";
+import { handleChunked, sendChunked } from "./chunking";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -431,12 +431,11 @@ function send(doc: WSSharedDoc, conn: Party.Connection, m: Uint8Array) {
     closeConn(doc, conn);
   }
   try {
-    conn.send(
-      m
-      // /** @param {any} err */ (err) => {
-      //   err != null && closeConn(doc, conn);
-      // }
-    );
+    if (typeof m !== "string") {
+      sendChunked(m, conn as unknown as WebSocket);
+    } else {
+      conn.send(m);
+    }
   } catch (e) {
     closeConn(doc, conn);
   }

--- a/packages/y-partykit/src/provider.ts
+++ b/packages/y-partykit/src/provider.ts
@@ -9,7 +9,6 @@ import * as awarenessProtocol from "y-protocols/awareness";
 import { Observable } from "lib0/observable";
 import * as math from "lib0/math";
 import * as url from "lib0/url";
-import { sendChunked } from "./chunking";
 
 export const messageSync = 0;
 export const messageQueryAwareness = 3;
@@ -560,14 +559,6 @@ type YPartyKitProviderOptions = Omit<
   params?: ParamsProvider;
 };
 
-class ChunkedWebSocket extends WebSocket {
-  send(data: string | ArrayBufferLike) {
-    if (typeof data !== "string") {
-      sendChunked(data, (chunk) => super.send(chunk));
-    }
-  }
-}
-
 export default class YPartyKitProvider extends WebsocketProvider {
   id: string;
   #params?: ParamsProvider;
@@ -611,7 +602,6 @@ export default class YPartyKitProvider extends WebsocketProvider {
     const baseOptions = {
       ...rest,
       connect: false,
-      WebSocketPolyfill: ChunkedWebSocket,
     };
 
     super(serverUrl, room, doc ?? new YDoc(), baseOptions);


### PR DESCRIPTION
The class definition was eagerly looking for a WebSocket class, breaking in non-standards based environments (like node.js), leading to issues like https://github.com/partykit/partykit/issues/698. This removes the class definition, and uses the chunking function directly when required. I think this should fix the problem.