### PR TITLE
chore: add metadata to `partysocket` for discoverability

### DIFF
--- a/.changeset/lemon-elephants-fry.md
+++ b/.changeset/lemon-elephants-fry.md
@@ -1,0 +1,5 @@
+---
+"partysocket": patch
+---
+
+chore: add metadata to `partysocket` package.json for discoverability

--- a/packages/partysocket/package.json
+++ b/packages/partysocket/package.json
@@ -1,7 +1,9 @@
 {
   "name": "partysocket",
   "version": "0.0.20",
-  "description": "party hotline",
+  "description": "A better WebSocket that Just Works™",
+  "homepage": "https://docs.partykit.io/reference/partysocket-api",
+  "bugs": "https://github.com/partykit/partykit/issues",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {
@@ -56,7 +58,22 @@
     "*.d.ts",
     "event-target-polyfill.*"
   ],
-  "keywords": [],
+  "keywords": [
+    "websocket",
+    "client",
+    "reconnecting",
+    "reconnection",
+    "reconnect",
+    "forever",
+    "persistent",
+    "forever",
+    "automatic"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/partykit/partykit.git",
+    "directory": "packages/partykit"
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
### Fixing discoverability on NPM

As of now, discoverability of the `partysocket` package on NPM is really poor as it won't show-up when searching for `websocket` and its description is not meaningful outside of PartyKit.

I tried to fix that by 
- filling `description` with the tagline from `README.md`
- filling `keywords` with those used by [reconnecting-websocket](https://github.com/pladaria/reconnecting-websocket)

### Fixing pointing to source from package

In the same way, once the package is installed (or found on npmjs.com) nothing links to this repository or PartyKit's homepage.

Fixing that by adding
- `homepage` pointing to the docs on PartyKit's homepage
- `bugs` pointing on this repo's issues page
- `repository` pointing to `partysocket` directory on this repo

