### PR TITLE
populate `process.env` with `.env` contents

### DIFF
--- a/.changeset/six-deers-hunt.md
+++ b/.changeset/six-deers-hunt.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+populate `process.env` with `.env` contents
+
+(as well as `.env.local` during `dev`)

--- a/examples/basic/src/server.ts
+++ b/examples/basic/src/server.ts
@@ -6,6 +6,8 @@ import type {
   PartyKitServer
 } from "partykit/server";
 
+console.log(process.env);
+
 declare global {
   const SOME_GLOBAL: string;
   const TEST_DEFINE_NUMBER: number;

--- a/packages/partykit/inject-process.js
+++ b/packages/partykit/inject-process.js
@@ -1,4 +1,10 @@
+/* global PARTYKIT_PROCESS_ENV */
 import * as process from "node:process";
 
-// TODO: populate process.env
+try {
+  Object.assign(process.env, JSON.parse(PARTYKIT_PROCESS_ENV));
+} catch (err) {
+  // no-op
+}
+
 export { process };

--- a/packages/partykit/src/config.ts
+++ b/packages/partykit/src/config.ts
@@ -348,6 +348,8 @@ export function getConfig(
     };
   }
 
+  const hasEnvVars = Object.keys(envVars).length > 0;
+
   configPath ||= getConfigPath();
 
   // do a quick check of the overrides
@@ -383,6 +385,9 @@ export function getConfig(
         ...removeUndefinedKeys(overrides.vars)
       },
       define: {
+        ...(hasEnvVars
+          ? { PARTYKIT_PROCESS_ENV: JSON.stringify(JSON.stringify(envVars)) }
+          : {}),
         ...(options?.withEnv ? { ...wrapValuesWithQuotes(envVars) } : {}),
         ...removeUndefinedKeys(packageJsonConfig.define),
         ...removeUndefinedKeys(overrides.define)
@@ -429,6 +434,9 @@ export function getConfig(
       ...removeUndefinedKeys(overrides.vars)
     },
     define: {
+      ...(hasEnvVars
+        ? { PARTYKIT_PROCESS_ENV: JSON.stringify(JSON.stringify(envVars)) }
+        : {}),
       ...(options?.withEnv ? { ...wrapValuesWithQuotes(envVars) } : {}),
       ...removeUndefinedKeys(parsedConfig.define),
       ...removeUndefinedKeys(overrides.define)

--- a/packages/partykit/src/tests/config.test.ts
+++ b/packages/partykit/src/tests/config.test.ts
@@ -54,7 +54,9 @@ describe("config", () => {
     const config = getConfig(undefined, undefined);
     expect(config).toMatchInlineSnapshot(`
       {
-        "define": {},
+        "define": {
+          "PARTYKIT_PROCESS_ENV": ""{\\"test\\":\\"test\\"}"",
+        },
         "vars": {
           "test": "test",
         },
@@ -71,7 +73,9 @@ describe("config", () => {
     });
     expect(config).toMatchInlineSnapshot(`
       {
-        "define": {},
+        "define": {
+          "PARTYKIT_PROCESS_ENV": ""{\\"test\\":\\"test\\"}"",
+        },
         "vars": {
           "test": "test2",
         },
@@ -93,7 +97,9 @@ describe("config", () => {
     );
     expect(config).toMatchInlineSnapshot(`
       {
-        "define": {},
+        "define": {
+          "PARTYKIT_PROCESS_ENV": ""{\\"test\\":\\"test3\\",\\"test2\\":\\"test2\\"}"",
+        },
         "vars": {
           "test": "test3",
           "test2": "test2",
@@ -137,7 +143,9 @@ describe("config", () => {
     const config = getConfig(undefined, undefined);
     expect(config).toMatchInlineSnapshot(`
       {
-        "define": {},
+        "define": {
+          "PARTYKIT_PROCESS_ENV": ""{\\"test\\":\\"test2\\"}"",
+        },
         "main": "./script.js",
         "vars": {
           "test": "test2",


### PR DESCRIPTION
(as well as `.env.local` during `dev`)