### PR TITLE
dev: add a flag `--disable-request-cf-fetch`

### DIFF
--- a/.changeset/few-doors-move.md
+++ b/.changeset/few-doors-move.md
@@ -1,0 +1,7 @@
+---
+"partykit": patch
+---
+
+dev: add a flag `--disable-request-cf-fetch`
+
+when miniflare starts, it makes a request to get data to populate request.cf. This might not be desirable in some secure environments. This PR adds a flag to disable that behaviour.

--- a/packages/partykit/src/bin.tsx
+++ b/packages/partykit/src/bin.tsx
@@ -150,6 +150,7 @@ program
   .option("--minify", "Minify the script")
   .option("--live", "Enable live reload")
   .option("--with-env", "Define all variables in the deployment")
+  .option("--disable-request-cf-fetch", "Disable populating request.cf")
   .option("--verbose", "Verbose debugging output")
   .action(async (scriptPath, options) => {
     await printBanner();
@@ -160,6 +161,7 @@ program
       >
         <Dev
           main={scriptPath}
+          disableRequestCfFetch={options.disableRequestCfFetch}
           unstable_outdir={options.unstable_outdir}
           port={options.port ? parseInt(options.port) : undefined}
           persist={options.persist}

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -340,6 +340,7 @@ export type DevProps = {
   withEnv?: boolean;
   verbose?: boolean;
   unstable_outdir?: string;
+  disableRequestCfFetch?: boolean;
   define?: Record<string, string>;
   onReady?: (host: string, port: number) => void;
   compatibilityDate?: string;
@@ -867,6 +868,7 @@ Workers["${name}"] = ${name};
 
                   void server.onBundleUpdate(
                     {
+                      cf: !options.disableRequestCfFetch,
                       https: options.https,
                       httpsKeyPath: options.httpsKeyPath,
                       httpsCertPath: options.httpsCertPath,
@@ -1086,7 +1088,8 @@ Workers["${name}"] = ${name};
     userDetails,
     options.https,
     options.httpsKeyPath,
-    options.httpsCertPath
+    options.httpsCertPath,
+    options.disableRequestCfFetch
   ]);
 
   const { onReady } = options;


### PR DESCRIPTION
when miniflare starts, it makes a request to get data to populate request.cf. This might not be desirable in some secure environments. This PR adds a flag to disable that behaviour.