### PR TITLE
y-partykit provider can generate IDs even if 'crypto' is not defined

### DIFF
--- a/.changeset/gentle-pigs-whisper.md
+++ b/.changeset/gentle-pigs-whisper.md
@@ -1,0 +1,5 @@
+---
+"y-partykit": patch
+---
+
+y-partykit provider can generate IDs even if 'crypto' is not defined

--- a/packages/y-partykit/src/provider.ts
+++ b/packages/y-partykit/src/provider.ts
@@ -529,7 +529,7 @@ export class WebsocketProvider extends Observable<string> {
 
 function generateUUID(): string {
   // Public Domain/MIT
-  if (crypto.randomUUID) {
+  if (crypto && crypto.randomUUID) {
     return crypto.randomUUID();
   }
   let d = new Date().getTime(); //Timestamp


### PR DESCRIPTION
y-partykit was failing in my environment (VSCode extension running in development mode) because 'crypto' is not defined. Simply adding an extra check to the already existing logic in order to fall back to insecure ID generation when 'crypto' is not defined.