### PR TITLE
docs: fix deploy partykit command

### DIFF
--- a/apps/docs/src/content/docs/tutorials/add-partykit-to-a-nextjs-app/7-deploy-your-app.md
+++ b/apps/docs/src/content/docs/tutorials/add-partykit-to-a-nextjs-app/7-deploy-your-app.md
@@ -14,7 +14,7 @@ While you don't need separate repositories for the client and the PartyKit serve
 To deploy your PartyKit server run the following command in your project directory:
 
 ```bash
-npm partykit deploy
+npx partykit deploy
 ```
 
 When the deployment completes, you will get your app's PartyKit URL. You will need this URL when deploying your Next.js app. The URL will follow the pattern of `[your project's name].[your GitHub username].partykit.dev`.


### PR DESCRIPTION
I noticed this when trying to deploy PartyKit from my CLI, here's what happens when I run `npm partykit deploy`:

```bash
$ npm partykit deploy
Unknown command: "partykit"

To see a list of supported npm commands, run:
  npm help
```

Whereas when I look at the [Deploying your PartyKit Server](https://docs.partykit.io/guides/deploying-your-partykit-server/) page, it used `npx partykit deploy` which worked as expected.