### PR TITLE
Update fetch error logging from console.error to console.warn

### DIFF
--- a/.changeset/purple-moles-appear.md
+++ b/.changeset/purple-moles-appear.md
@@ -1,0 +1,5 @@
+---
+"partykit": patch
+---
+
+Update fetch error logging from console.error to console.warn

--- a/packages/partykit/facade/source.ts
+++ b/packages/partykit/facade/source.ts
@@ -1005,7 +1005,7 @@ export default {
         });
       }
     } catch (e) {
-      console.error("fetch error", e);
+      console.warn("fetch error", e);
       return new Response(e instanceof Error ? e.message : `${e}`, {
         status: 500
       });


### PR DESCRIPTION
The underlying PartyKit framework logs an error which gets forwarded to the same tail logger that is set up for the top level application. Since our team uses the tail logger to set up alarms, this specific `console.error` does get called every so often when we deploy. The error we receive is:
```
fetch error
Error: Durable Object reset because its code was updated.
```

The change here is to log a warn instead since this might still be worthwhile to log but the application itself can appropriately handle the actual error and decide how to move forward.