### PR TITLE
'prefix' option for PartySocket/YPartyKitProvider

### DIFF
--- a/.changeset/slow-icons-jump.md
+++ b/.changeset/slow-icons-jump.md
@@ -1,0 +1,8 @@
+---
+"partysocket": patch
+"y-partykit": patch
+---
+
+'prefix' option for PartySocket/YPartyKitProvider
+
+We currently assume that parties are routed to by /parties/:party/:room (or /party/:room for the default party.) However, there will be upcoming changes where parties can be routed to on the basis of any url (or even any other param, like a session id or whatever). This change lets clients connect with a `prefix` param. It also uses /parties/main/:room when connecting to the default party. This is not a breaking change, all projects should still just work as expected.

--- a/packages/partysocket/src/index.ts
+++ b/packages/partysocket/src/index.ts
@@ -14,6 +14,7 @@ export type PartySocketOptions = Omit<RWS.Options, "constructor"> & {
   host: string; // base url for the party
   room?: string; // the room to connect to
   party?: string; // the party to connect to (defaults to main)
+  prefix?: string; // the prefix to use for the party
   protocol?: "ws" | "wss";
   protocols?: string[];
   path?: string; // the path to connect to
@@ -25,6 +26,7 @@ export type PartyFetchOptions = {
   host: string; // base url for the party
   room: string; // the room to connect to
   party?: string; // the party to fetch from (defaults to main)
+  prefix?: string; // the prefix to use for the party
   path?: string; // the path to fetch from
   protocol?: "http" | "https";
   query?: Params | (() => Params | Promise<Params>);
@@ -68,6 +70,7 @@ function getPartyInfo(
     protocol: rawProtocol,
     room,
     party,
+    prefix,
     query
   } = partySocketOptions;
 
@@ -99,9 +102,7 @@ function getPartyInfo(
       : // https / wss
         defaultProtocol + "s");
 
-  const baseUrl = `${protocol}://${host}/${
-    party ? `parties/${party}` : "party"
-  }/${room}${path}`;
+  const baseUrl = `${protocol}://${host}/${prefix || `parties/${name}/${room}`}${path}`;
 
   const makeUrl = (query: Params = {}) =>
     `${baseUrl}?${new URLSearchParams([


### PR DESCRIPTION
We currently assume that parties are routed to by /parties/:party/:room (or /party/:room for the default party.) However, there will be upcoming changes where parties can be routed to on the basis of any url (or even any other param, like a session id or whatever). This change lets clients connect with a `prefix` param. It also uses /parties/main/:room when connecting to the default party. This is not a breaking change, all projects should still just work as expected.