### PR TITLE
Move y-partykit deps to peerDependencies

### DIFF
--- a/.changeset/late-pumas-pull.md
+++ b/.changeset/late-pumas-pull.md
@@ -1,0 +1,5 @@
+---
+"y-partykit": patch
+---
+
+Move y-partykit deps to peerDependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -51556,13 +51556,20 @@
       "license": "ISC",
       "dependencies": {
         "lib0": "^0.2.94",
-        "lodash.debounce": "^4.0.8",
+        "lodash.debounce": "^4.0.8"
+      },
+      "devDependencies": {
+        "@types/lodash.debounce": "^4.0.9"
+      },
+      "peerDependencies": {
         "react": "^18.2.0",
         "y-protocols": "^1.0.6",
         "yjs": "^13.6.16"
       },
-      "devDependencies": {
-        "@types/lodash.debounce": "^4.0.9"
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/packages/y-partykit/package.json
+++ b/packages/y-partykit/package.json
@@ -57,9 +57,16 @@
   },
   "dependencies": {
     "lib0": "^0.2.94",
-    "lodash.debounce": "^4.0.8",
+    "lodash.debounce": "^4.0.8"
+  },
+  "peerDependencies": {
     "react": "^18.2.0",
     "y-protocols": "^1.0.6",
     "yjs": "^13.6.16"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
Marks yjs and react as peerDependencies.

The react hook (and dependency) would ideally be in a separate package, but I've made it optional here.
