### PR TITLE
Fix spelling error in existing project setup guide

### DIFF
--- a/apps/docs/src/content/docs/add-to-existing-project.md
+++ b/apps/docs/src/content/docs/add-to-existing-project.md
@@ -34,7 +34,7 @@ npx partykit dev
 Add desired behavior to your server, and connect it to the UI.
 
 :::tip[Where to start?]
-If you don't now where to start, follow our [guide to building a WebSocket server](/guides).
+If you don't know where to start, follow our [guide to building a WebSocket server](/guides).
 :::
 
 ## Deploy your app


### PR DESCRIPTION
This is an extremely minor PR. It simply corrects a misspelling in the [Add to Existing Project guide](https://docs.partykit.io/add-to-existing-project/).

Thanks!