### PR TITLE
Nodejs compat upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21082,7 +21082,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
       "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
-      "dev": true,
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
@@ -22339,8 +22338,7 @@
     "node_modules/defu": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "dev": true
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
     },
     "node_modules/delaunator": {
       "version": "5.0.0",
@@ -36224,8 +36222,7 @@
     "node_modules/node-fetch-native": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
-      "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==",
-      "dev": true
+      "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ=="
     },
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
@@ -44520,6 +44517,15 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -45858,16 +45864,16 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unenv": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.9.0.tgz",
-      "integrity": "sha512-QKnFNznRxmbOF1hDgzpqrlIf6NC5sbZ2OJ+5Wl3OX8uM+LUJXbj4TXvLJCtwbPTmbMHCLIz6JLKNinNsMShK9g==",
-      "dev": true,
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.10.0.tgz",
+      "integrity": "sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==",
+      "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3",
-        "defu": "^6.1.3",
+        "defu": "^6.1.4",
         "mime": "^3.0.0",
-        "node-fetch-native": "^1.6.1",
-        "pathe": "^1.1.1"
+        "node-fetch-native": "^1.6.4",
+        "pathe": "^1.1.2"
       }
     },
     "node_modules/unherit": {
@@ -50535,6 +50541,8 @@
         "clipboardy": "4.0.0",
         "esbuild": "0.21.5",
         "miniflare": "3.20240718.0",
+        "ts-dedent": "^2.2.0",
+        "unenv": "^1.10.0",
         "yoga-wasm-web": "0.3.3"
       },
       "bin": {

--- a/packages/partykit/package.json
+++ b/packages/partykit/package.json
@@ -48,6 +48,8 @@
     "clipboardy": "4.0.0",
     "esbuild": "0.21.5",
     "miniflare": "3.20240718.0",
+    "ts-dedent": "^2.2.0",
+    "unenv": "^1.10.0",
     "yoga-wasm-web": "0.3.3"
   },
   "optionalDependencies": {

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -29,7 +29,7 @@ import { Dev } from "./dev";
 import { fetchResult } from "./fetchResult";
 import InkTable from "./ink-table";
 import { ConfigurationError, logger } from "./logger";
-import nodejsCompatPlugin, { supportedNodeBuiltins } from "./nodejs-compat";
+import nodejsCompatPlugin from "./nodejs-compat";
 import { translateCLICommandToFilterMessage } from "./tail/filters";
 import { jsonPrintLogs, prettyPrintLogs } from "./tail/printing";
 
@@ -953,20 +953,6 @@ export const ${name} = ${name}Party;
     form.set(
       uploadFileName,
       new File([buffer], uploadFileName, { type: "application/octet-stream" })
-    );
-  }
-
-  // init node modules
-  for (const nodeModuleName of supportedNodeBuiltins) {
-    form.set(
-      `upload/partykit-exposed-node-${nodeModuleName}`,
-      new File(
-        [
-          `export * from 'node:${nodeModuleName}';export { default } from 'node:${nodeModuleName}';`
-        ],
-        `upload/partykit-exposed-node-${nodeModuleName}`,
-        { type: "application/javascript+module" }
-      )
     );
   }
 

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -20,7 +20,7 @@ import { getConfig, getUser } from "./config";
 import { API_BASE } from "./fetchResult";
 import useInspector from "./inspect";
 import { logger } from "./logger";
-import nodejsCompatPlugin, { supportedNodeBuiltins } from "./nodejs-compat";
+import nodejsCompatPlugin from "./nodejs-compat";
 import { openInBrowser } from "./open-in-browser";
 
 import type { VectorizeClientOptions } from "../facade/vectorize";
@@ -960,11 +960,6 @@ Workers["${name}"] = ${name};
                           path: absoluteScriptPath,
                           contents: code
                         },
-                        ...supportedNodeBuiltins.map((name) => ({
-                          type: "ESModule",
-                          contents: `export * from 'node:${name}'; export { default } from 'node:${name}';`,
-                          path: `${path.dirname(absoluteScriptPath)}/partykit-exposed-node-${name}`
-                        })),
 
                         // KEEP IN SYNC with deploy()
                         {

--- a/packages/partykit/src/nodejs-compat.ts
+++ b/packages/partykit/src/nodejs-compat.ts
@@ -1,51 +1,248 @@
-import type { Plugin } from "esbuild";
+import { builtinModules } from "node:module";
+import nodePath from "node:path";
 
-// via https://developers.cloudflare.com/workers/runtime-apis/nodejs/
-export const supportedNodeBuiltins = [
-  "assert",
-  "async_hooks",
-  "buffer",
-  "diagnostics_channel",
-  "events",
-  "path",
-  "process",
-  "stream",
-  "string_decoder",
-  "util",
-  "crypto"
-];
+import dedent from "ts-dedent";
+import { cloudflare, env, nodeless } from "unenv";
 
-const plugin: Plugin = {
-  name: "nodejs-compat",
-  setup(build) {
-    // mark all cloudflare:* imports as external
-    build.onResolve({ filter: /^cloudflare:/ }, (args) => {
-      const cloudflareModuleName = args.path.split(":")[1];
-      return {
-        path: `partykit-exposed-cloudflare-${cloudflareModuleName}`,
-        external: true
-      };
-    });
+import { getBasePath } from "./path";
 
-    build.onResolve({ filter: /^node:/ }, (args) => {
-      const name = args.path.replace(/^node:/, "");
-      if (supportedNodeBuiltins.includes(name)) {
-        return { path: `partykit-exposed-node-${name}`, external: true };
-      } else {
-        throw new Error(`Unsupported node builtin: ${name}`);
-      }
-    });
-    build.onResolve(
-      { filter: new RegExp(`^(${supportedNodeBuiltins.join("|")})$`) },
-      async (args) => {
-        // TODO: we want to use import.meta.resolve here
-        // but it's too early to use, and my experiments with
-        // it always log node:process (instead of any existing package)
-        // So let's land this and revisit if folks want differently
-        return { path: `partykit-exposed-node-${args.path}`, external: true };
-      }
-    );
-  }
+import type { Plugin, PluginBuild } from "esbuild";
+
+const REQUIRED_NODE_BUILT_IN_NAMESPACE = "node-built-in-modules";
+const REQUIRED_UNENV_ALIAS_NAMESPACE = "required-unenv-alias";
+
+/**
+ * Creates a plugin for `workerd` compatibility with Node.js APIs.
+ *
+ * @see https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
+ * @returns The plugin.
+ */
+export const createNodeHybridPlugin: () => Plugin = () => {
+  const { alias, inject, external } = env(nodeless, cloudflare);
+  return {
+    name: "nodejs-compat",
+    setup(build) {
+      errorOnServiceWorkerFormat(build);
+      handleRequireCallsToNodeJSBuiltins(build);
+      handleUnenvAliasedPackages(build, alias, external);
+      handleNodeJSGlobals(build, inject);
+    }
+  };
 };
 
-export default plugin;
+const NODEJS_MODULES_RE = new RegExp(`^(node:)?(${builtinModules.join("|")})$`);
+
+/**
+ * If we are bundling a "Service Worker" formatted Worker, imports of external modules,
+ * which won't be inlined/bundled by esbuild, are invalid.
+ *
+ * This `onResolve()` handler will error if it identifies node.js external imports.
+ */
+function errorOnServiceWorkerFormat(build: PluginBuild) {
+  const paths = new Set();
+  build.onStart(() => paths.clear());
+  build.onResolve({ filter: NODEJS_MODULES_RE }, (args) => {
+    paths.add(args.path);
+    return null;
+  });
+  build.onEnd(() => {
+    if (build.initialOptions.format === "iife" && paths.size > 0) {
+      const pathList = new Intl.ListFormat("en-US").format(
+        Array.from(paths.keys())
+          .map((p) => `"${p}"`)
+          .sort()
+      );
+      return {
+        errors: [
+          {
+            text: dedent`
+							Unexpected external import of ${pathList}.
+							Your worker has no default export, which means it is assumed to be a Service Worker format Worker.
+							Did you mean to create a ES Module format Worker?
+							If so, try adding \`export default { ... }\` in your entry-point.
+							See https://developers.cloudflare.com/workers/reference/migrate-to-module-workers/.
+						`
+          }
+        ]
+      };
+    }
+  });
+}
+
+/**
+ * We must convert `require()` calls for Node.js modules to a virtual ES Module that can be imported avoiding the require calls.
+ * We do this by creating a special virtual ES module that re-exports the library in an onLoad handler.
+ * The onLoad handler is triggered by matching the "namespace" added to the resolve.
+ */
+function handleRequireCallsToNodeJSBuiltins(build: PluginBuild) {
+  build.onResolve({ filter: NODEJS_MODULES_RE }, (args) => {
+    if (args.kind === "require-call") {
+      return {
+        path: args.path,
+        namespace: REQUIRED_NODE_BUILT_IN_NAMESPACE
+      };
+    }
+  });
+  build.onLoad(
+    { filter: /.*/, namespace: REQUIRED_NODE_BUILT_IN_NAMESPACE },
+    ({ path }) => {
+      return {
+        contents: dedent`
+					import libDefault from '${path}';
+					module.exports = libDefault;`,
+        loader: "js"
+      };
+    }
+  );
+}
+
+function handleUnenvAliasedPackages(
+  build: PluginBuild,
+  alias: Record<string, string>,
+  external: string[]
+) {
+  // esbuild expects alias paths to be absolute
+  const aliasAbsolute: Record<string, string> = {};
+  for (const [module, unresolvedAlias] of Object.entries(alias)) {
+    try {
+      aliasAbsolute[module] = require
+        .resolve(unresolvedAlias)
+        .replace(/\.cjs$/, ".mjs");
+    } catch (e) {
+      // this is an alias for package that is not installed in the current app => ignore
+    }
+  }
+
+  const UNENV_ALIAS_RE = new RegExp(
+    `^(${Object.keys(aliasAbsolute).join("|")})$`
+  );
+
+  build.onResolve({ filter: UNENV_ALIAS_RE }, (args) => {
+    const unresolvedAlias = alias[args.path];
+    // Convert `require()` calls for NPM packages to a virtual ES Module that can be imported avoiding the require calls.
+    // Note: Does not apply to Node.js packages that are handled in `handleRequireCallsToNodeJSBuiltins`
+    if (
+      args.kind === "require-call" &&
+      (unresolvedAlias.startsWith("unenv/runtime/npm/") ||
+        unresolvedAlias.startsWith("unenv/runtime/mock/"))
+    ) {
+      return {
+        path: args.path,
+        namespace: REQUIRED_UNENV_ALIAS_NAMESPACE
+      };
+    }
+    // Resolve the alias to its absolute path and potentially mark it as external
+    return {
+      path: aliasAbsolute[args.path],
+      external: external.includes(unresolvedAlias)
+    };
+  });
+
+  build.initialOptions.banner = { js: "", ...build.initialOptions.banner };
+  build.initialOptions.banner.js += dedent`
+		function __cf_cjs(esm) {
+		  const cjs = 'default' in esm ? esm.default : {};
+			for (const [k, v] of Object.entries(esm)) {
+				if (k !== 'default') {
+					Object.defineProperty(cjs, k, {
+						enumerable: true,
+						value: v,
+					});
+				}
+			}
+			return cjs;
+		}
+		`;
+
+  build.onLoad(
+    { filter: /.*/, namespace: REQUIRED_UNENV_ALIAS_NAMESPACE },
+    ({ path }) => {
+      return {
+        contents: dedent`
+					import * as esm from '${path}';
+					module.exports = __cf_cjs(esm);
+				`,
+        loader: "js"
+      };
+    }
+  );
+}
+
+/**
+ * Inject node globals defined in unenv's `inject` config via virtual modules
+ */
+function handleNodeJSGlobals(
+  build: PluginBuild,
+  inject: Record<string, string | string[]>
+) {
+  const UNENV_GLOBALS_RE = /_virtual_unenv_global_polyfill-([^.]+)\.js$/;
+  const prefix = nodePath.resolve(
+    getBasePath(),
+    "_virtual_unenv_global_polyfill-"
+  );
+
+  build.initialOptions.inject = [
+    ...(build.initialOptions.inject ?? []),
+    //convert unenv's inject keys to absolute specifiers of custom virtual modules that will be provided via a custom onLoad
+    ...Object.keys(inject).map(
+      (globalName) => `${prefix}${encodeToLowerCase(globalName)}.js`
+    )
+  ];
+
+  build.onResolve({ filter: UNENV_GLOBALS_RE }, ({ path }) => ({ path }));
+
+  build.onLoad({ filter: UNENV_GLOBALS_RE }, ({ path }) => {
+    // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
+    const globalName = decodeFromLowerCase(path.match(UNENV_GLOBALS_RE)![1]);
+    const { importStatement, exportName } = getGlobalInject(inject[globalName]);
+
+    return {
+      contents: dedent`
+				${importStatement}
+				globalThis.${globalName} = ${exportName};
+			`
+    };
+  });
+}
+
+/**
+ * Get the import statement and export name to be used for the given global inject setting.
+ */
+function getGlobalInject(globalInject: string | string[]) {
+  if (typeof globalInject === "string") {
+    // the mapping is a simple string, indicating a default export, so the string is just the module specifier.
+    return {
+      importStatement: `import globalVar from "${globalInject}";`,
+      exportName: "globalVar"
+    };
+  }
+  // the mapping is a 2 item tuple, indicating a named export, made up of a module specifier and an export name.
+  const [moduleSpecifier, exportName] = globalInject;
+  return {
+    importStatement: `import { ${exportName} } from "${moduleSpecifier}";`,
+    exportName
+  };
+}
+
+/**
+ * Encodes a case sensitive string to lowercase string.
+ *
+ * - Escape $ with another $ ("$" -> "$$")
+ * - Escape uppercase letters with $ and turn them into lowercase letters ("L" -> "$L")
+ *
+ * This function exists because ESBuild requires that all resolved paths are case insensitive.
+ * Without this transformation, ESBuild will clobber /foo/bar.js with /foo/Bar.js
+ */
+export function encodeToLowerCase(str: string): string {
+  return str.replace(/[A-Z$]/g, (escape) => `$${escape.toLowerCase()}`);
+}
+
+/**
+ * Decodes a string lowercased using `encodeToLowerCase` to the original strings
+ */
+export function decodeFromLowerCase(str: string): string {
+  return str.replace(/\$[a-z$]/g, (escaped) => escaped[1].toUpperCase());
+}
+
+const nodeHybridPlugin = createNodeHybridPlugin();
+export default nodeHybridPlugin;

--- a/packages/partykit/src/path.ts
+++ b/packages/partykit/src/path.ts
@@ -1,0 +1,24 @@
+import path from "node:path";
+
+/**
+ * The __RELATIVE_PACKAGE_PATH__ is defined either in the esbuild config (for production)
+ * or the vitest.setup.ts (for unit testing).
+ *
+ * @see https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/paths.ts#L61
+ */
+declare const __RELATIVE_PACKAGE_PATH__: string;
+
+/**
+ * Use this function (rather than Node.js constants like `__dirname`) to specify
+ * paths that are relative to the base path of the Partykit package.
+ *
+ * It is important to use this function because it reliably maps to the root of the package
+ * no matter whether the code has been bundled or not.
+ *
+ * @see https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/paths.ts#L70
+ * @returns The base path of the Partykit package.
+ */
+export function getBasePath(): string {
+  // eslint-disable-next-line no-restricted-globals
+  return path.resolve(__dirname, __RELATIVE_PACKAGE_PATH__);
+}


### PR DESCRIPTION
## Summary
Since September 23, 2024, Cloudflare [has allowed devs to opt into improved Node.js compatibility](https://blog.cloudflare.com/more-npm-packages-on-cloudflare-workers-combining-polyfills-and-native-code/). This update enables Wrangler users to work with [many more Node.js APIs](https://workers-nodejs-compat-matrix.pages.dev/) than is [currently available](https://github.com/partykit/partykit/blob/main/packages/partykit/src/nodejs-compat.ts).

Behind the scenes, Cloudflare's Wrangler [uses the `unenv` library's polyfills](https://blog.cloudflare.com/more-npm-packages-on-cloudflare-workers-combining-polyfills-and-native-code/) where natively supported Node APIs fall short. Based on the Wrangler package's source code, I've updated Partykit's `nodejs-compat-plugin` to do the same. 

## Changes made
* Set up reliable means of getting relative path mapping to root of package, as seen [here](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/paths.ts#L61) and [here](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/scripts/bundle.ts#L26).
* Update nodejs-compat plugin to combine previously supported Node.js APIs with unenv polyfills. We combine `unenv`'s `cloudflare` and `nodeless` presets. The plugin now closely resembles the one seen [here](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts). This is the plugin Wrangler uses [(source)](url).
* Clean up nodejs-compat plugin usages in `cli.tsx` and `dev.tsx` previously needed to support Node.js APIs, that are not needed anymore.

## Impact
* Hard-coded names of supported Node.js APIs are no longer present. The combination of `cloudflare` and `nodeless` presets in `unenv` are used instead. API support can be viewed [in this matrix's right-most column](https://workers-nodejs-compat-matrix.pages.dev/), and [unenv docs](https://workers-nodejs-compat-matrix.pages.dev/).
* PartyKit users can now access the same Node.js APIs that they would with Wrangler.

## Notes
As a proof-of-concept, I forked the [`partykit` NPM package](https://www.npmjs.com/package/@maryam-dev/partykit) and made these same changes (plus fork setup). Then, I created a [starter React + PartyKit project](https://github.com/maryam-khan-dev/farmer-drive), which simply shows that the `os` API now works. 