### PR TITLE
Fix filePath broken on windows

### DIFF
--- a/.changeset/path-prefix-thing.md
+++ b/.changeset/path-prefix-thing.md
@@ -1,0 +1,8 @@
+---
+"partykit": patch
+---
+
+Fix bad URL on windows, from `path.join( import.meta.url, "../dist/generated.js" )`
+which produces url startring with `.\\file:\\`, that incorrectly has `.\\`.
+
+Changes to `partykit/src/dev.tsx` and `partykit/src/cli.tsx`

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -334,7 +334,7 @@ export async function init(options: {
                 "init",
                 "index.ts"
               )
-              .replace(/^.\\/, '') // remove .\\ prefix
+              .replace(/^.\\file:/, 'file:') // fix .\\ prefix on windows
             )
           );
           console.log(`‣ Created ${chalk.bold("party/index.ts")}`);
@@ -348,7 +348,7 @@ export async function init(options: {
                 "init",
                 "index.js"
               )
-              .replace(/^.\\/, '') // remove .\\ prefix
+              .replace(/^.\\file:/, 'file:') // fix .\\ prefix on windows
             )
           );
           console.log(`‣ Created ${chalk.bold("party/index.js")}`);

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -721,7 +721,7 @@ export const ${name} = ${name}Party;
       inject: [
         fileURLToPath(
           path.join(path.dirname(import.meta.url), "../inject-process.js")
-          .replace(/^.\\/, '') // remove .\\ prefix from path for windows
+          .replace(/^.\\file:/, 'file:') // fix .\\ prefix on windows
         )
       ],
       alias: config.build?.alias,

--- a/packages/partykit/src/cli.tsx
+++ b/packages/partykit/src/cli.tsx
@@ -334,6 +334,7 @@ export async function init(options: {
                 "init",
                 "index.ts"
               )
+              .replace(/^.\\/, '') // remove .\\ prefix
             )
           );
           console.log(`‣ Created ${chalk.bold("party/index.ts")}`);
@@ -347,6 +348,7 @@ export async function init(options: {
                 "init",
                 "index.js"
               )
+              .replace(/^.\\/, '') // remove .\\ prefix
             )
           );
           console.log(`‣ Created ${chalk.bold("party/index.js")}`);
@@ -719,6 +721,7 @@ export const ${name} = ${name}Party;
       inject: [
         fileURLToPath(
           path.join(path.dirname(import.meta.url), "../inject-process.js")
+          .replace(/^.\\/, '') // remove .\\ prefix from path for windows
         )
       ],
       alias: config.build?.alias,

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -751,6 +751,7 @@ function useDev(options: DevProps): {
       const workerFacade = fs.readFileSync(
         fileURLToPath(
           path.join(path.dirname(import.meta.url), "../dist/generated.js")
+          .replace(/^.\\/, '') // remove .\\ prefix from path for windows
         ),
         "utf8"
       );
@@ -799,6 +800,7 @@ Workers["${name}"] = ${name};
         inject: [
           fileURLToPath(
             path.join(path.dirname(import.meta.url), "../inject-process.js")
+            .replace(/^.\\/, '') // remove .\\ prefix from path for windows
           )
         ],
         define: {

--- a/packages/partykit/src/dev.tsx
+++ b/packages/partykit/src/dev.tsx
@@ -751,7 +751,7 @@ function useDev(options: DevProps): {
       const workerFacade = fs.readFileSync(
         fileURLToPath(
           path.join(path.dirname(import.meta.url), "../dist/generated.js")
-          .replace(/^.\\/, '') // remove .\\ prefix from path for windows
+          .replace(/^.\\file:/, 'file:') // fix .\\ prefix on windows
         ),
         "utf8"
       );
@@ -800,7 +800,7 @@ Workers["${name}"] = ${name};
         inject: [
           fileURLToPath(
             path.join(path.dirname(import.meta.url), "../inject-process.js")
-            .replace(/^.\\/, '') // remove .\\ prefix from path for windows
+            .replace(/^.\\file:/, 'file:') // fix .\\ prefix on windows
           )
         ],
         define: {


### PR DESCRIPTION
Following the quickstart guide, on windows, with bun, when starting the dev server, I encountered this error:

```
🎈 PartyKit v0.0.100
---------------------
TypeError: Invalid URL
    at new URL (node:internal/url:818:25)
    at fileURLToPath (node:internal/url:1505:12)
    at runBuild (file:///C:/Projects/Game/partykit/node_modules/partykit/dist/bin.mjs:89389:9)
    at file:///C:/Projects/Game/partykit/node_modules/partykit/dist/bin.mjs:89683:5
    at Og (file:///C:/Projects/Game/partykit/node_modules/partykit/dist/bin.mjs:10275:27)
    at Ph (file:///C:/Projects/Game/partykit/node_modules/partykit/dist/bin.mjs:11708:31)
    at Mh (file:///C:/Projects/Game/partykit/node_modules/partykit/dist/bin.mjs:11251:9)
    at ad (file:///C:/Projects/Game/partykit/node_modules/partykit/dist/bin.mjs:7933:21)
    at J (file:///C:/Projects/Game/partykit/node_modules/partykit/dist/bin.mjs:7165:21)
    at Immediate.R (file:///C:/Projects/Game/partykit/node_modules/partykit/dist/bin.mjs:7199:15) {
  code: 'ERR_INVALID_URL',
  input: '.\\file:\\C:\\Projects\\Game\\partykit\\node_modules\\partykit\\dist\\generated.js'
}
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ [b] open a browser, [c] clear console, [x] to exit                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

Which comes from `packages/partykit/src/dev.tsx:753`:

```ts
  const workerFacade = fs.readFileSync(
    fileURLToPath(
      path.join(path.dirname(import.meta.url), "../dist/generated.js")
    ),
    "utf8"
  );
```

Investigating you can find that:

```ts
console.log( path.dirname( import.meta.url ) )
// output: file:///C:/Projects/Game/partykit/node_modules/partykit/dist

console.log( path.join( path.dirname( import.meta.url ), "../dist/generated.js") )
// output: .\\file:\\C:\\Projects\\Game\\partykit\\node_modules\\partykit\\dist\\generated.js
```

Seems like the `path.join` is adding a relative prefix to an absolute path.
Adding this `.replace()` fixes the problem (at least on my system):

```ts
  path.join(path.dirname(import.meta.url), "../dist/generated.js")
  .replace(/^.\\/, '') // remove .\\ prefix from path for windows
```

This is needed in a couple places that are doing the same `path.joing` with `import.meta.url`:

- /packages/partykit/src/dev.tsx:753
- /packages/partykit/src/dev.tsx:803

And probably here too:
- /packages/partykit/src/cli.tsx:338
- /packages/partykit/src/cli.tsx:350
- /packages/partykit/src/cli.tsx:721

I am having trouble **building** the monorepo on my system, but I can confirm the changes work if I modify the installed package directly on `node_modules/partykit/dist`. I don't know the project, so I might be missing something.

### Related

Probably related to issue [fix filePath in windows](https://github.com/partykit/partykit/pull/409), which added `file.replace( /\\/g, "/")` around line 645 in `dev.tsx`.
Maybe also has to do with recent pull #938 which added `basePath` to `partysocket`.