### PR TITLE
fix: disable exponential reconnect in WebSocketProvider

### DIFF
--- a/packages/y-partykit/src/provider.ts
+++ b/packages/y-partykit/src/provider.ts
@@ -180,16 +180,9 @@ function setupWS(provider: WebsocketProvider) {
       } else {
         provider.wsUnsuccessfulReconnects++;
       }
-      // Start with no reconnect timeout and increase timeout by
-      // using exponential backoff starting with 100ms
-      setTimeout(
-        setupWS,
-        math.min(
-          math.pow(2, provider.wsUnsuccessfulReconnects) * 100,
-          provider.maxBackoffTime
-        ),
-        provider
-      );
+      // Removed exponential reconnect logic to prevent repeated automatic connections.
+      // Reconnection is now fully controlled by the UI or calling code.
+      
     });
     websocket.addEventListener("open", () => {
       provider.wsLastMessageReceived = time.getUnixTime();


### PR DESCRIPTION
Previously, the WebSocketProvider in /packages/y-partykit/src/provider.ts
automatically attempted reconnections using an exponential backoff, starting
from 100ms. This caused repeated connections even when the UI specified a
fixed connection count.

This change removes the automatic exponential reconnect logic entirely.
Reconnection is now fully controlled by the UI or calling code.

Changes made in:
- /packages/y-partykit/src/provider.ts

Summary of changes:
- Removed setTimeout exponential reconnect
- Added a comment explaining why the logic was removed
